### PR TITLE
Updated license references - fixes gh-1

### DIFF
--- a/automatic/vscode-chrome-debug/legal/VERIFICATION.txt
+++ b/automatic/vscode-chrome-debug/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 509B828294DE647893ED6FE53E2B492D9D45C47DEF06EB804C9CE048EC978E78
 
-  File LICENSE.txt is obtained from https://https://raw.githubusercontent.com/microsoft/vscode-chrome-debug/master/LICENSE.txt
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/msjsdiag.debugger-for-chrome/license

--- a/automatic/vscode-chrome-debug/vscode-chrome-debug.nuspec
+++ b/automatic/vscode-chrome-debug/vscode-chrome-debug.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@1d50526002930359ca29f0722608cc1f0cf99e37/icons/vscode-chrome-debug.png</iconUrl>
     <copyright>Copyright 2015-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://github.com/microsoft/vscode-chrome-debug/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/msjsdiag.debugger-for-chrome/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Microsoft/vscode-chrome-debug</projectSourceUrl>
     <docsUrl>https://github.com/microsoft/vscode-chrome-debug/blob/master/README.md</docsUrl>

--- a/automatic/vscode-edge-debug/legal/VERIFICATION.txt
+++ b/automatic/vscode-edge-debug/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 3B0680C82A4968EB73E7CC1631B1C88C2EC66B37F60BF25272D2A7ACFE3DD3BE
 
-  File LICENSE.txt is obtained from https://raw.githubusercontent.com/microsoft/vscode-edge-debug2/master/LICENSE.txt
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/msjsdiag.debugger-for-edge/license

--- a/automatic/vscode-edge-debug/vscode-edge-debug.nuspec
+++ b/automatic/vscode-edge-debug/vscode-edge-debug.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@236a257aaf4920b7b1b4c6b0cd29eca8c5026e91/icons/vscode-edge-debug.png</iconUrl>
     <copyright>Copyright 2016-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://github.com/microsoft/vscode-edge-debug2/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/msjsdiag.debugger-for-edge/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/microsoft/vscode-edge-debug2</projectSourceUrl>
     <docsUrl>https://github.com/microsoft/vscode-edge-debug2/blob/master/README.md</docsUrl>

--- a/automatic/vscode-firefox-debug/legal/VERIFICATION.txt
+++ b/automatic/vscode-firefox-debug/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: E432F7BC96D913016A9DB3D1ABAAE227CC2FBFA2FAFFBAC7C8DA832B89D32AE3
 
-  File LICENSE.txt is obtained from https://raw.githubusercontent.com/firefox-devtools/vscode-firefox-debug/master/LICENSE
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/firefox-devtools.vscode-firefox-debug/license

--- a/automatic/vscode-firefox-debug/vscode-firefox-debug.nuspec
+++ b/automatic/vscode-firefox-debug/vscode-firefox-debug.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-debug</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@268b298a417edf0d8583c0695aab704f7940cef3/icons/vscode-firefox-debug.png</iconUrl>
     <copyright>Copyright 2016-2019 Holger Benl</copyright>
-    <licenseUrl>https://github.com/firefox-devtools/vscode-firefox-debug/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/firefox-devtools.vscode-firefox-debug/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/firefox-devtools/vscode-firefox-debug</projectSourceUrl>
     <docsUrl>https://github.com/firefox-devtools/vscode-firefox-debug/blob/master/README.md</docsUrl>

--- a/automatic/vscode-intellicode/legal/VERIFICATION.txt
+++ b/automatic/vscode-intellicode/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 9707525B01C9F125ACE2D34342B2E556ADFE73E0E9978371093CD4194BC39EB5
 
-  File LICENSE.txt is obtained from https://raw.githubusercontent.com/MicrosoftDocs/intellicode/master/LICENSE-CODE
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/VisualStudioExptTeam.vscodeintellicode/license

--- a/automatic/vscode-intellicode/vscode-intellicode.nuspec
+++ b/automatic/vscode-intellicode/vscode-intellicode.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@8c5592c5c04a7de4544145427fb03cbe2ac9b969/icons/vscode-intellicode.png</iconUrl>
     <copyright>Copyright 2018-2019 Microsoft</copyright>
-    <licenseUrl>https://github.com/MicrosoftDocs/intellicode/blob/master/LICENSE-CODE</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/VisualStudioExptTeam.vscodeintellicode/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/MicrosoftDocs/intellicode</projectSourceUrl>
     <docsUrl>https://github.com/MicrosoftDocs/intellicode/blob/master/docs/intellicode-visual-studio-code.md</docsUrl>

--- a/automatic/vscode-java-debug/legal/VERIFICATION.txt
+++ b/automatic/vscode-java-debug/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: F98A35C8DD4F3079ECD9657B04F1EDBFEA04C364C0FBF7EEE1285F942782710B
 
-  File LICENSE.txt is obtained from https://github.com/microsoft/vscode-java-debug/blob/master/LICENSE.txt
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/vscjava.vscode-java-debug/license

--- a/automatic/vscode-java-debug/vscode-java-debug.nuspec
+++ b/automatic/vscode-java-debug/vscode-java-debug.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@003fee8d66c6e11583d5d142c9670f419e859d15/icons/vscode-java-debug.png</iconUrl>
     <copyright>Copyright 2017-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://github.com/microsoft/vscode-java-debug/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/vscjava.vscode-java-debug/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/microsoft/vscode-java-debug</projectSourceUrl>
     <docsUrl>https://github.com/Microsoft/vscode-java-debug/blob/master/README.md</docsUrl>

--- a/automatic/vscode-java-dependency/legal/VERIFICATION.txt
+++ b/automatic/vscode-java-dependency/legal/VERIFICATION.txt
@@ -25,4 +25,4 @@ vspackage
   Type:     sha256
   Checksum: B6934E58B92B476476DDE50ADCC5358D9042CC4A81F8FF4F1F49857F5BB97766
 
-  File LICENSE.txt is obtained from https://github.com/microsoft/vscode-java-dependency/blob/master/LICENSE
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/vscjava.vscode-java-dependency/license

--- a/automatic/vscode-java-dependency/vscode-java-dependency.nuspec
+++ b/automatic/vscode-java-dependency/vscode-java-dependency.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-dependency</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@33c7b8a0ff12bfe0fc3aedcce40b74c6184c9e11/icons/vscode-java-dependency.png</iconUrl>
     <copyright>Copyright 2018-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://github.com/microsoft/vscode-java-dependency/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/vscjava.vscode-java-dependency/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/microsoft/vscode-java-dependency/</projectSourceUrl>
     <docsUrl>https://github.com/Microsoft/vscode-java-dependency/blob/master/README.md</docsUrl>

--- a/automatic/vscode-java-test/legal/VERIFICATION.txt
+++ b/automatic/vscode-java-test/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: DA0D72D6FAB5786551181736A230F50ED4AE2F13E4C28FEF4BAC431140F71C21
 
-  File LICENSE.txt is obtained from https://github.com/microsoft/vscode-java-test/blob/master/LICENSE.txt
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/vscjava.vscode-java-test/license

--- a/automatic/vscode-java-test/vscode-java-test.nuspec
+++ b/automatic/vscode-java-test/vscode-java-test.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-test</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@8efbf94309d2d79bfe2ec5e0ce26104a36a2d4d2/icons/vscode-java-test.png</iconUrl>
     <copyright>Copyright 2017-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://github.com/microsoft/vscode-java-test/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/vscjava.vscode-java-test/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/microsoft/vscode-java-test</projectSourceUrl>
     <docsUrl>https://github.com/microsoft/vscode-java-test/blob/master/README.md</docsUrl>

--- a/automatic/vscode-java/legal/VERIFICATION.txt
+++ b/automatic/vscode-java/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 7A90BB26D63930253646643BA5F60E162D4E803F2806C32AC586C4B37B88DBB3
 
-  File LICENSE.txt is obtained from https://github.com/redhat-developer/vscode-java/blob/master/LICENSE
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/redhat.java/license

--- a/automatic/vscode-java/vscode-java.nuspec
+++ b/automatic/vscode-java/vscode-java.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=redhat.java</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@27cefa4e9cecaae41e719fb7ed7564439eb46c46/icons/vscode-java.png</iconUrl>
     <copyright>Copyright 2016-2019 Red Hat</copyright>
-    <licenseUrl>https://github.com/redhat-developer/vscode-java/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/redhat.java/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/redhat-developer/vscode-java</projectSourceUrl>
     <docsUrl>https://github.com/redhat-developer/vscode-java/wiki</docsUrl>

--- a/automatic/vscode-kubernetes-tools/legal/VERIFICATION.txt
+++ b/automatic/vscode-kubernetes-tools/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 85745A2F742C6352F41DE291679B8E1A6F12FADA9D3E036812C0F33E1373EDF2
 
-  File LICENSE.txt is obtained from https://raw.githubusercontent.com/Azure/vscode-kubernetes-tools/master/LICENSE
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/ms-kubernetes-tools.vscode-kubernetes-tools/license

--- a/automatic/vscode-kubernetes-tools/vscode-kubernetes-tools.nuspec
+++ b/automatic/vscode-kubernetes-tools/vscode-kubernetes-tools.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@04c2c097ddd064697ce5d666d0dc3138ac671dbc/icons/vscode-kubernetes-tools.png</iconUrl>
     <copyright>Copyright 2018-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://github.com/Azure/vscode-kubernetes-tools/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/ms-kubernetes-tools.vscode-kubernetes-tools/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Azure/vscode-kubernetes-tools</projectSourceUrl>
     <docsUrl>https://github.com/Azure/vscode-kubernetes-tools/blob/master/README.md</docsUrl>

--- a/automatic/vscode-maven/legal/VERIFICATION.txt
+++ b/automatic/vscode-maven/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 0AD94B76CFBA3CFD6091B9B73CDA79AE7B65AB771BCF06D1F50DC1526EA13C67
 
-  File LICENSE.txt is obtained from https://github.com/microsoft/vscode-maven/blob/master/LICENSE.txt
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/vscjava.vscode-maven/license

--- a/automatic/vscode-maven/vscode-maven.nuspec
+++ b/automatic/vscode-maven/vscode-maven.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@df6a42399764d6755fc05671a467f4fea2904d74/icons/vscode-maven.png</iconUrl>
     <copyright>Copyright 2017-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://github.com/microsoft/vscode-maven/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/vscjava.vscode-maven/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/microsoft/vscode-maven/</projectSourceUrl>
     <docsUrl>https://github.com/Microsoft/vscode-maven/blob/v0.19.1/README.md</docsUrl>

--- a/automatic/vscode-prettier/legal/VERIFICATION.txt
+++ b/automatic/vscode-prettier/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 41E54FD90BBD1F75E34B1CC1332A4556D29B500FCC3A228928BE664A84B552A0
 
-  File LICENSE.txt is obtained from https://raw.githubusercontent.com/prettier/prettier-vscode/master/LICENSE
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/esbenp.prettier-vscode/license

--- a/automatic/vscode-prettier/vscode-prettier.nuspec
+++ b/automatic/vscode-prettier/vscode-prettier.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@d31db90d323ade71b0e3ea960b09d38516d59d0f/icons/vscode-prettier.png</iconUrl>
     <copyright>Copyright 2017-2019 Prettier</copyright>
-    <licenseUrl>https://github.com/prettier/prettier-vscode/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://marketplace.visualstudio.com/items/esbenp.prettier-vscode/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/prettier/prettier-vscode</projectSourceUrl>
     <docsUrl>https://github.com/prettier/prettier-vscode/blob/master/README.md</docsUrl>

--- a/automatic/vscode-python/legal/VERIFICATION.txt
+++ b/automatic/vscode-python/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 6A9EDF9ECABED14AAC424E6007858068204A3638BF3BB4F235BD6035D823ACC6
 
-  File LICENSE.txt is obtained from https://github.com/microsoft/vscode-python/blob/master/LICENSE
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/ms-python.python/license

--- a/automatic/vscode-todo-tree/legal/VERIFICATION.txt
+++ b/automatic/vscode-todo-tree/legal/VERIFICATION.txt
@@ -24,4 +24,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: AA7A5CF73C4D6D590E546533D1A2F7B0D29125C1BFD94BE1260CEA3A8A7294B8
 
-  File LICENSE.txt is obtained from https://github.com/Gruntfuggly/todo-tree/blob/master/License.txt
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/Gruntfuggly.todo-tree/license


### PR DESCRIPTION
Updated license references to use those in the extension distribution
rather than the source code repository.  This was to address the
possibility that the licensing for the binary distribution and the
source code may diverge over time.  Given it is the binary which is
being redistributed the license needed to be aligned.