### PR TITLE
(gh-30) Removed explicit VSCode dependencies

### DIFF
--- a/automatic/vscode-azure-deploy/README.md
+++ b/automatic/vscode-azure-deploy/README.md
@@ -12,11 +12,10 @@ This VS Code extension helps you set up continuous build and deployment for Azur
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.32.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-azure-deploy/update.ps1
+++ b/automatic/vscode-azure-deploy/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'ms-vscode-deploy-azure'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-azure-deploy/vscode-azure-deploy.nuspec
+++ b/automatic/vscode-azure-deploy/vscode-azure-deploy.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vscode-azure-deploy</id>
-    <version>1.0.0</version>
+    <version>1.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/vscode-azure-deploy</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Deploy to Azure VSCode Extension</title>
@@ -24,11 +24,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.15.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -37,7 +36,6 @@
   <releaseNotes>https://marketplace.visualstudio.com/items/ms-vscode-deploy-azure.azure-deploy/changelog</releaseNotes>
   <dependencies>
     <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-    <dependency id="vscode" version="1.32.0" />
   </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-chrome-debug/README.md
+++ b/automatic/vscode-chrome-debug/README.md
@@ -27,11 +27,10 @@ A VS Code extension to debug your JavaScript code in the Google Chrome browser, 
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.32.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-chrome-debug/update.ps1
+++ b/automatic/vscode-chrome-debug/update.ps1
@@ -7,8 +7,12 @@ $publisher = 'msjsdiag'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                     = "`${1}$($Latest.Copyright)`${3}"
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-chrome-debug/vscode-chrome-debug.nuspec
+++ b/automatic/vscode-chrome-debug/vscode-chrome-debug.nuspec
@@ -39,11 +39,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.17.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -52,7 +51,6 @@
     <releaseNotes>https://github.com/microsoft/vscode-chrome-debug/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.17.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-cloud-code/README.md
+++ b/automatic/vscode-cloud-code/README.md
@@ -24,11 +24,10 @@ Cloud Code for VS Code extends VS Code to bring all the power and convenience of
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.38.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-cloud-code/update.ps1
+++ b/automatic/vscode-cloud-code/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'GoogleCloudTools'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-cloud-code/vscode-cloud-code.nuspec
+++ b/automatic/vscode-cloud-code/vscode-cloud-code.nuspec
@@ -36,11 +36,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.38.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -49,7 +48,6 @@
     <releaseNotes>https://marketplace.visualstudio.com/items/GoogleCloudTools.cloudcode/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.38.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-edge-debug/README.md
+++ b/automatic/vscode-edge-debug/README.md
@@ -27,11 +27,10 @@ A VS Code extension to debug your JavaScript code in the Microsoft Edge browser.
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.17.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-edge-debug/update.ps1
+++ b/automatic/vscode-edge-debug/update.ps1
@@ -7,8 +7,12 @@ $publisher = 'msjsdiag'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                     = "`${1}$($Latest.Copyright)`${3}"
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-edge-debug/vscode-edge-debug.nuspec
+++ b/automatic/vscode-edge-debug/vscode-edge-debug.nuspec
@@ -39,11 +39,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.17.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -51,7 +50,6 @@
 ]]></description>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.17.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-firefox-debug/README.md
+++ b/automatic/vscode-firefox-debug/README.md
@@ -22,17 +22,14 @@ A VS Code extension to debug web applications and extensions running in the [Moz
 * Pause on object property changes with [Data breakpoints](https://code.visualstudio.com/docs/editor/debugging#_data-breakpoints) (Works with Firefox 70)
 * Use VS Code's (new UI for column breakpoints)[https://code.visualstudio.com/updates/v1_39#_improved-ui-for-column-breakpoints]
 
-
-![screenshot](./screenshot.png)
-
+![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@268b298a417edf0d8583c0695aab704f7940cef3/automatic/vscode-firefox-debug/screenshot.png)
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.39.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-firefox-debug/update.ps1
+++ b/automatic/vscode-firefox-debug/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'firefox-devtools'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-firefox-debug/vscode-firefox-debug.nuspec
+++ b/automatic/vscode-firefox-debug/vscode-firefox-debug.nuspec
@@ -38,11 +38,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.39.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -51,7 +50,6 @@
     <releaseNotes>https://github.com/firefox-devtools/vscode-firefox-debug/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.39.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-go/README.md
+++ b/automatic/vscode-go/README.md
@@ -23,11 +23,10 @@ This extension adds rich language support for the [Go language](https://golang.o
 ## Notes
 
 * Additional Go tool setup is required to use this extension so follow the instructions in [how to use this extension](https://github.com/microsoft/vscode-go/blob/master/README.md#how-to-use-this-extension)
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.30.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-go/update.ps1
+++ b/automatic/vscode-go/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'ms-vscode'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-go/vscode-go.nuspec
+++ b/automatic/vscode-go/vscode-go.nuspec
@@ -35,11 +35,10 @@
 ## Notes
 
 * Additional Go tool setup is required to use this extension so follow the instructions in [how to use this extension](https://github.com/microsoft/vscode-go/blob/master/README.md#how-to-use-this-extension)
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.30.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -48,7 +47,6 @@
     <releaseNotes>https://marketplace.visualstudio.com/items/ms-vscode.Go/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.30.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-intellicode/README.md
+++ b/automatic/vscode-intellicode/README.md
@@ -18,11 +18,10 @@ Contextual recommendations are based on practices developed in thousands of high
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.29.1 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-intellicode/update.ps1
+++ b/automatic/vscode-intellicode/update.ps1
@@ -7,8 +7,12 @@ $publisher = 'VisualStudioExptTeam'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                     = "`${1}$($Latest.Copyright)`${3}"
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
@@ -21,9 +25,9 @@ function global:au_GetLatest {
   $extensionInfo = Get-VSMarketplaceExtensionDetails -Extension $extension -Publisher $publisher
 
   @{
-    Copyright      = $extensionInfo.Copyright
-    Version        = $extensionInfo.Version
-    VSCodeVersion  = $extensionInfo.VSCodeVersion
+    Copyright     = $extensionInfo.Copyright
+    Version       = $extensionInfo.Version
+    VSCodeVersion = $extensionInfo.VSCodeVersion
   }
 }
 

--- a/automatic/vscode-intellicode/vscode-intellicode.nuspec
+++ b/automatic/vscode-intellicode/vscode-intellicode.nuspec
@@ -30,11 +30,10 @@ Contextual recommendations are based on practices developed in thousands of high
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.29.1 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -43,7 +42,6 @@ Contextual recommendations are based on practices developed in thousands of high
     <releaseNotes>https://marketplace.visualstudio.com/items/VisualStudioExptTeam.vscodeintellicode/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.29.1" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-java-debug/README.md
+++ b/automatic/vscode-java-debug/README.md
@@ -26,11 +26,10 @@ A lightweight Java Debugger based on [Java Debug Server](https://github.com/Micr
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.32.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-java-debug/update.ps1
+++ b/automatic/vscode-java-debug/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'vscjava'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-java-debug/vscode-java-debug.nuspec
+++ b/automatic/vscode-java-debug/vscode-java-debug.nuspec
@@ -38,11 +38,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.32.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -51,7 +50,6 @@
     <releaseNotes>https://github.com/microsoft/vscode-java-debug/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.32.0" />
       <dependency id="vscode-java" version="0.14.0" />
     </dependencies>
   </metadata>

--- a/automatic/vscode-java-dependency/README.md
+++ b/automatic/vscode-java-dependency/README.md
@@ -17,11 +17,10 @@ A lightweight extension to provide additional Java project explorer features. It
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.28.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-java-dependency/update.ps1
+++ b/automatic/vscode-java-dependency/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'vscjava'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-java-dependency/vscode-java-dependency.nuspec
+++ b/automatic/vscode-java-dependency/vscode-java-dependency.nuspec
@@ -29,11 +29,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.28.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -42,7 +41,6 @@
     <releaseNotes>https://github.com/microsoft/vscode-java-dependency/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.28.0" />
       <dependency id="vscode-java" version="0.32.0" />
     </dependencies>
   </metadata>

--- a/automatic/vscode-java-test/README.md
+++ b/automatic/vscode-java-test/README.md
@@ -26,11 +26,10 @@ The [Java Test Runner](https://marketplace.visualstudio.com/items?itemName=vscja
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.32.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-java-test/update.ps1
+++ b/automatic/vscode-java-test/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'vscjava'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-java-test/vscode-java-test.nuspec
+++ b/automatic/vscode-java-test/vscode-java-test.nuspec
@@ -38,11 +38,10 @@ The [Java Test Runner](https://marketplace.visualstudio.com/items?itemName=vscja
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.32.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -51,7 +50,6 @@ The [Java Test Runner](https://marketplace.visualstudio.com/items?itemName=vscja
     <releaseNotes>https://github.com/microsoft/vscode-java-test/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.32.0" />
       <dependency id="vscode-java" />
       <dependency id="vscode-java-debug" />
     </dependencies>

--- a/automatic/vscode-java/README.md
+++ b/automatic/vscode-java/README.md
@@ -31,15 +31,14 @@ Provides Java™ language support via [Eclipse™ JDT Language Server](<https://
 * Semantic selection
 * Diagnostic tags
 
+![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@27cefa4e9cecaae41e719fb7ed7564439eb46c46/automatic/vscode-java/screenshot.png)
+
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.36.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
-
-![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@27cefa4e9cecaae41e719fb7ed7564439eb46c46/automatic/vscode-java/screenshot.png)

--- a/automatic/vscode-java/update.ps1
+++ b/automatic/vscode-java/update.ps1
@@ -7,10 +7,13 @@ $publisher = 'redhat'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                     = "`${1}$($Latest.Copyright)`${3}"
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
     ".\tools\chocolateyinstall.ps1" = @{
       "([0-9]+\.[0-9]+\.[0-9]+)" = "$($Latest.Version)"
     }

--- a/automatic/vscode-java/vscode-java.nuspec
+++ b/automatic/vscode-java/vscode-java.nuspec
@@ -47,11 +47,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.36.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-kubernetes-tools/README.md
+++ b/automatic/vscode-kubernetes-tools/README.md
@@ -29,11 +29,10 @@ Works with any Kubernetes anywhere (Azure, Minikube, AWS, GCP and more!).
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.31.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-kubernetes-tools/update.ps1
+++ b/automatic/vscode-kubernetes-tools/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'ms-kubernetes-tools'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-kubernetes-tools/vscode-kubernetes-tools.nuspec
+++ b/automatic/vscode-kubernetes-tools/vscode-kubernetes-tools.nuspec
@@ -41,19 +41,18 @@ Works with any Kubernetes anywhere (Azure, Minikube, AWS, GCP and more!).
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.31.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
+
 ]]></description>
     <releaseNotes>https://github.com/Azure/vscode-kubernetes-tools/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.31.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-maven/README.md
+++ b/automatic/vscode-maven/README.md
@@ -19,11 +19,10 @@ Maven extension for VS Code. It provides a project explorer and shortcuts to exe
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.37.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-maven/update.ps1
+++ b/automatic/vscode-maven/update.ps1
@@ -7,8 +7,12 @@ $publisher = 'vscjava'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(/v)([0-9]+\.[0-9]+\.[0-9]+)(/)" = "`${1}$($Latest.Version)/"
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(/v)([0-9]+\.[0-9]+\.[0-9]+)(/)"                          = "`${1}$($Latest.Version)/"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-maven/vscode-maven.nuspec
+++ b/automatic/vscode-maven/vscode-maven.nuspec
@@ -31,11 +31,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.37.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -44,7 +43,6 @@
     <releaseNotes>https://github.com/microsoft/vscode-maven/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.37.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-prettier/README.md
+++ b/automatic/vscode-prettier/README.md
@@ -18,11 +18,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.34.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-prettier/update.ps1
+++ b/automatic/vscode-prettier/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'esbenp'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-prettier/vscode-prettier.nuspec
+++ b/automatic/vscode-prettier/vscode-prettier.nuspec
@@ -30,11 +30,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.34.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -43,7 +42,6 @@
     <releaseNotes>https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.34.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-python/README.md
+++ b/automatic/vscode-python/README.md
@@ -24,11 +24,10 @@ refactoring, variable explorer, test explorer, snippets, and more!
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.38.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-python/update.ps1
+++ b/automatic/vscode-python/update.ps1
@@ -7,8 +7,12 @@ $publisher = 'ms-python'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                     = "`${1}$($Latest.Copyright)`${3}"
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-python/vscode-python.nuspec
+++ b/automatic/vscode-python/vscode-python.nuspec
@@ -33,11 +33,10 @@
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.38.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -47,7 +46,6 @@
     <releaseNotes>https://marketplace.visualstudio.com/items/ms-python.python/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.38.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-todo-tree/README.md
+++ b/automatic/vscode-todo-tree/README.md
@@ -12,11 +12,10 @@ Found TODOs can also be highlighted in open files.
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.5.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-todo-tree/update.ps1
+++ b/automatic/vscode-todo-tree/update.ps1
@@ -7,8 +7,12 @@ $publisher = 'Gruntfuggly'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                     = "`${1}$($Latest.Copyright)`${3}"
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-todo-tree/vscode-todo-tree.nuspec
+++ b/automatic/vscode-todo-tree/vscode-todo-tree.nuspec
@@ -22,23 +22,22 @@
 
 Found TODOs can also be highlighted in open files.
 
+![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@5804bdc4730cde93947ce391ea948e305c3cc472/automatic/vscode-todo-tree/screenshot.png)
+
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.5.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
-![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@5804bdc4730cde93947ce391ea948e305c3cc472/automatic/vscode-todo-tree/screenshot.png)
 ]]></description>
     <releaseNotes>https://marketplace.visualstudio.com/items/Gruntfuggly.todo-tree/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.5.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/vscode-vsonline/README.md
+++ b/automatic/vscode-vsonline/README.md
@@ -16,11 +16,10 @@ Learn more at [online.visualstudio.com](http://online.visualstudio.com/).
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.39.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/vscode-vsonline/update.ps1
+++ b/automatic/vscode-vsonline/update.ps1
@@ -7,7 +7,11 @@ $publisher = 'ms-vsonline'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(id=`"vscode`"\sversion=`")([0-9]+\.[0-9]+\.[0-9]+)" = "`${1}$($Latest.VSCodeVersion)"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+    }
+
+    ".\README.md" = @{
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{

--- a/automatic/vscode-vsonline/vscode-vsonline.nuspec
+++ b/automatic/vscode-vsonline/vscode-vsonline.nuspec
@@ -28,11 +28,10 @@ Learn more at [online.visualstudio.com](http://online.visualstudio.com/).
 
 ## Notes
 
-* This package requires Visual Studio Code.
+* This package requires Visual Studio Code 1.39.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
-* The extension will be installed in any edition of Visual Studio Code which can be found.
-* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup
-  if there's a newer version available on the marketplace.
+* The extension will be installed in all editions of Visual Studio Code which can be found.
+* While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.
   See [Extension auto-update](https://code.visualstudio.com/docs/editor/extension-gallery#_extension-autoupdate) for instructions on how to disable auto-update.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
@@ -41,7 +40,6 @@ Learn more at [online.visualstudio.com](http://online.visualstudio.com/).
     <releaseNotes>https://marketplace.visualstudio.com/items/ms-vsonline.vsonline/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
-      <dependency id="vscode" version="1.39.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
VSCode extension packages had an explicit dependency on a version
of Visual Studio Code.  This removed choice from users as it forces the
install of a VSCode version which may not be inline with user intent, especially if the user is employing an alternate distribution such as vscode-
insiders or vscodium.

Updated packages to remove the dependency and shift the version
identification requirements to documentation.