### PR TITLE
(gh-36) Updated description and verification URLs.

### DIFF
--- a/automatic/vscode-java-debug/legal/VERIFICATION.txt
+++ b/automatic/vscode-java-debug/legal/VERIFICATION.txt
@@ -15,7 +15,7 @@ in the Resources section of the sidebar.
 
 Alternatively the package can be downloaded directly from
 
-  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vcsjava/vsextensions/vscode-java/0.24.0/vspackage
+  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vcsjava/vsextensions/vscode-java-debug/0.24.0/vspackage
 
 2. The extension can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash vscjava.vscode-java-debug-0.24.0.vsix

--- a/automatic/vscode-java-debug/vscode-java-debug.nuspec
+++ b/automatic/vscode-java-debug/vscode-java-debug.nuspec
@@ -34,7 +34,7 @@
 * Evaluation
 * Hot Code Replace
 
-![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@003fee8d66c6e11583d5d142c9670f419e859d15/automatic/vscode-java-debugger/screenshot.png)
+![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@003fee8d66c6e11583d5d142c9670f419e859d15/automatic/vscode-java-debug/screenshot.png)
 
 ## Notes
 


### PR DESCRIPTION
The description and verification URLs were incorrect.  Updated the
screenshot CDN URL to remove eroneous package extensions and
amended the direct package download verification URL to add the
full package name.