### PR TITLE
(gh-58) Updated package title, copyright notice and other documentation

### DIFF
--- a/automatic/neck-diagrams/README.md
+++ b/automatic/neck-diagrams/README.md
@@ -1,4 +1,4 @@
-﻿# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@aaced40197b4b4f40922fd84260d77cd7214efc9/icons/neck-diagrams.png" width="48" height="48" /> Neck Diagrams 2](<https://chocolatey.org/packages/neck-diagrams>)
+﻿# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@aaced40197b4b4f40922fd84260d77cd7214efc9/icons/neck-diagrams.png" width="48" height="48" /> Neck Diagrams](<https://chocolatey.org/packages/neck-diagrams>)
 
 [![Software license](https://img.shields.io/badge/license-Proprietary-lightgrey)](https://www.neckdiagrams.com/license)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)

--- a/automatic/neck-diagrams/neck-diagrams.nuspec
+++ b/automatic/neck-diagrams/neck-diagrams.nuspec
@@ -4,13 +4,13 @@
   <metadata>
     <id>neck-diagrams</id>
     <version>2.0.3</version>
-    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/automatic/neck-diagrams</packageSourceUrl>
+    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/neck-diagrams</packageSourceUrl>
     <owners>dgalbraith</owners>
-    <title>Neck Diagrams 2</title>
+    <title>Neck Diagrams</title>
     <authors>Digital Software Technology Ltd</authors>
     <projectUrl>https://www.neckdiagrams.com</projectUrl>
-    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@aaced40197b4b4f40922fd84260d77cd7214efc9/automatic/neck-diagrams/icon.png</iconUrl>
-    <copyright>2008-2019 Digital Software Technology Ltd</copyright>
+    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@aaced40197b4b4f40922fd84260d77cd7214efc9/icons/neck-diagrams.png</iconUrl>
+    <copyright>2008-2020 Digital Software Technology Ltd</copyright>
     <licenseUrl>https://www.neckdiagrams.com/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>neck-diagrams fretboard-diagram chord-chart chord-box-creator fretboard chord-box diagram trial</tags>
@@ -36,7 +36,7 @@ Neck Diagrams is a powerful tool that creates fretboard diagrams, chord charts a
   * scale generator can be used up to 10 times
 
 ]]></description>
-    <releaseNotes>https://www.neckdiagrams.com/download/version-history</releaseNotes>
+    <releaseNotes>https://www.neckdiagrams.com/download/release-notes</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
Updated package title to remove the version from the title - the version
is supplied in the package tag.
Updated the Copyright notice to reflect updates in the year 2020.
Updated package source URL.
Updated package icon URL.
Updated release notes URL.