### PR TITLE
(gh-59) removed invalid matching regex

### DIFF
--- a/automatic/neck-diagrams/update.ps1
+++ b/automatic/neck-diagrams/update.ps1
@@ -7,7 +7,6 @@ $releases = 'https://www.neckdiagrams.com/download'
 function global:au_SearchReplace {
     @{
         ".\tools\chocolateyInstall.ps1" = @{
-          "(\s*version\s*=\s*)('.*')"         = "`$1'$($Latest.Version)'"
           "(\s*url\s*=\s*)('.*')"             = "`$1'$($Latest.URL32)'"
           "(\s*url64bit\s*=\s*)('.*')"        = "`$1'$($Latest.URL64)'"
           "(\s*checksum\s*=\s*)('.*')"        = "`$1'$($Latest.Checksum32)'"


### PR DESCRIPTION
Updated au_SearchReplace to remove the "(\s*version\s*=\s*)('.*')"
update to ensure successful token replacement in chocolateyInstall.ps1.
Token replacement was failing as there is no match for the string version=
in the target file.