### PR TITLE
(gh-57) Updated package titles and copyright notices

### DIFF
--- a/manual/winaero-tweaker.install/winaero-tweaker.install.nuspec
+++ b/manual/winaero-tweaker.install/winaero-tweaker.install.nuspec
@@ -6,11 +6,11 @@
     <version>0.16.1.0</version>
     <owners>bcurran3,dgalbraith</owners>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/manual/winaero-tweaker.install</packageSourceUrl>
-    <title>Winaero Tweaker</title>
+    <title>Winaero Tweaker (Install)</title>
     <authors>Sergey Tkachenko</authors>
     <projectUrl>http://winaero.com/index.php</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@13e084a993db7ca0e2260759355fb12d225be4dd/icons/winaero-tweaker.png</iconUrl>
-    <copyright>Sergey Tkachenko</copyright>
+    <copyright>Copyright Sergey Tkachenko</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>http://winaero.com/blog/winaero-tweaker-faq/</docsUrl>
     <bugTrackerUrl>http://winaero.com/comment.php?comment.news.1836</bugTrackerUrl>

--- a/manual/winaero-tweaker.portable/winaero-tweaker.portable.nuspec
+++ b/manual/winaero-tweaker.portable/winaero-tweaker.portable.nuspec
@@ -6,11 +6,11 @@
     <version>0.16.1.0</version>
     <owners>bcurran3,dgalbraith</owners>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/manual/winaero-tweaker.portable</packageSourceUrl>
-    <title>Winaero Tweaker</title>
+    <title>Winaero Tweaker (Portable)</title>
     <authors>Sergey Tkachenko</authors>
     <projectUrl>http://winaero.com/index.php</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@13e084a993db7ca0e2260759355fb12d225be4dd/icons/winaero-tweaker.png</iconUrl>
-    <copyright>© Winaero.com</copyright>
+    <copyright>Copyright Sergey Tkachenko</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>http://winaero.com/blog/winaero-tweaker-faq/</docsUrl>
     <bugTrackerUrl>http://winaero.com/comment.php?comment.news.1836</bugTrackerUrl>

--- a/manual/winaero-tweaker/winaero-tweaker.nuspec
+++ b/manual/winaero-tweaker/winaero-tweaker.nuspec
@@ -10,7 +10,7 @@
     <authors>Sergey Tkachenko</authors>
     <projectUrl>http://winaero.com/index.php</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@13e084a993db7ca0e2260759355fb12d225be4dd/icons/winaero-tweaker.png</iconUrl>
-    <copyright>Sergey Tkachenko</copyright>
+    <copyright>Copyright Sergey Tkachenko</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>http://winaero.com/blog/winaero-tweaker-faq/</docsUrl>
     <bugTrackerUrl>http://winaero.com/comment.php?comment.news.1836</bugTrackerUrl>


### PR DESCRIPTION
Package titles for Winaero Tweaker did not differentiate the install and
portable versions from  the meta package and were updated to include
Install and Portable in the title.

Copyright notices were updated to include the text Copyright.