### PR TITLE
(gh-72) Update package title

### DIFF
--- a/automatic/keys/README.md
+++ b/automatic/keys/README.md
@@ -1,4 +1,4 @@
-# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@6524dd81768c37021fdcf6d6a0ab9b15243005aa/icons/keys.png" width="48" height="48"/>keys](<https://chocolatey.org/packages/keys>)
+# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@6524dd81768c37021fdcf6d6a0ab9b15243005aa/icons/keys.png" width="48" height="48"/>Keys - Cryptographic Key Management](<https://chocolatey.org/packages/keys>)
 
 [![GitHub license](https://img.shields.io/github/license/keys-pub/keys)](https://github.com/keys-pub/keys/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)

--- a/automatic/keys/keys.nuspec
+++ b/automatic/keys/keys.nuspec
@@ -6,7 +6,7 @@
     <version>0.0.45</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/keys</packageSourceUrl>
     <owners>dgalbraith</owners>
-    <title>keys</title>
+    <title>Keys - Cryptographic Key Management</title>
     <authors>Gabriel Handford</authors>
     <projectUrl>https://keys.pub/</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@6524dd81768c37021fdcf6d6a0ab9b15243005aa/icons/keys.png</iconUrl>


### PR DESCRIPTION
The package title was co-indident with the package name and did not
convey any information as to the purpose of the package.  The title was
updated to provide additional detail.