### PR TITLE
(gh-82) Updated regex matching installer in update script

### DIFF
--- a/automatic/keys/update.ps1
+++ b/automatic/keys/update.ps1
@@ -16,7 +16,7 @@ function global:au_SearchReplace {
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "(\s')(sd.+64.+\.zip)" = "`${1}$($Latest.Filename64)"
+      "(Keys.+msi)" = "$($Latest.Filename64)"
     }
 
     ".\legal\VERIFICATION.txt" = @{


### PR DESCRIPTION
The regex to match the installer on update was not corrrect.  The regex
in place would not match msi which would cause an automated update to
fail.  Corrected the regex so it would correctly pick up the Keys msi.