### PR TITLE
(gh-83) Updated URL matched for version in update script

### DIFF
--- a/automatic/kyma-cli/update.ps1
+++ b/automatic/kyma-cli/update.ps1
@@ -42,7 +42,7 @@ function global:au_GetLatest {
   $url64SegmentSize = $([System.Uri]$url64).Segments.Length
   $filename64 = $([System.Uri]$url64).Segments[$url64SegmentSize - 1]
 
-  $url -match $reversion
+  $url64 -match $reversion
   $version = $Matches.Version
 
   return @{


### PR DESCRIPTION
The URL used to match against when determining the version is empty so
the version matching will return nothing.  To ensure a version is
returned when the update script is run the version match needs to be
performed against a populated URL.

Updated the URL used for the match to $url64 to achieve this.