### PR TITLE
(gh-93) Corrected icon URL in package definition

### DIFF
--- a/automatic/tunein-radio/README.md
+++ b/automatic/tunein-radio/README.md
@@ -17,7 +17,7 @@ The TuneIn desktop app improves how you browse and discover content from all ove
 
 ## Notes
 
-* The installer is a combined installer containing both 32 and 64-bit versions but it is not possible to specify which to install on a 64-bit system.  The
-  installer will always use the version of the application matching the bitness of the OS.
+* The installer is a combined installer containing both 32 and 64-bit versions but it is not possible to specify which to install on a 64-bit
+  system.  The installer will always use the version of the application matching the bitness of the OS.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/tunein-radio/tunein-radio.nuspec
+++ b/automatic/tunein-radio/tunein-radio.nuspec
@@ -9,7 +9,7 @@
     <title>TuneIn Radio Desktop</title>
     <authors>TuneIn Inc.</authors>
     <projectUrl>https://tunein.com/</projectUrl>
-    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@4ca4bb149356048ba158a4e3e0ae5ae1d0b9ac22/icons/tunin-radio.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@4ca4bb149356048ba158a4e3e0ae5ae1d0b9ac22/icons/tunein-radio.png</iconUrl>
     <copyright>Copyright TuneIn Inc.</copyright>
     <licenseUrl>https://tunein.com/policies/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
The package definition was not correct due to the non-locateable icon.
The icon was not locatable due to an error in the URL.  To correct the
package definition the URL was corrected so that the icon could be
accessed at the URL.

The documentation was also updated to remove a linebreak such that the
display was clean.