### PR TITLE
(gh-102) Removed version specification from dependency

### DIFF
--- a/automatic/tldr/tldr.nuspec
+++ b/automatic/tldr/tldr.nuspec
@@ -28,12 +28,10 @@ The [tldr pages](https://tldr.sh/) are a community effort to simplify the belove
 
 * This is a meta-package which resolves to a preferred Windows client for tldr.  This is currently the [tldr++](https://isacikgoz.me/tldr/) client by
 İbrahim Serdar Açıkgöz but this may change over time.
-* This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
-  If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
     <dependencies>
-      <dependency id="tldr-plusplus" version="(0.6.1,)" />
+      <dependency id="tldr-plusplus" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
The definition of the tldr++ client dependency was incorrect.  With an
exclusive minimum version matching the desired dependency version it
was not being located successfully.

Given the behaviour of the Chocolatey internal Nuspec version for an
unspecified dependency version is to locate the highest available
version there is in fact no need for an explicit version so this was
removed.