### PR TITLE
(gh-107) Updated documentation references to reflect default branch name change

### DIFF
--- a/automatic/vscode-prettier/README.md
+++ b/automatic/vscode-prettier/README.md
@@ -1,6 +1,6 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@d31db90d323ade71b0e3ea960b09d38516d59d0f/icons/vscode-prettier.png" width="48" height="48" />Prettier Code Formatter VSCode Extension](<https://chocolatey.org/packages/vscode-prettier>)
 
-[![GitHub license](https://img.shields.io/github/license/prettier/prettier-vscode)](https://github.com/prettier/prettier-vscode/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/prettier/prettier-vscode)](https://github.com/prettier/prettier-vscode/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
 [![Visual Studio Marketplace version](https://img.shields.io/visual-studio-marketplace/v/esbenp.prettier-vscode?label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)

--- a/automatic/vscode-prettier/vscode-prettier.nuspec
+++ b/automatic/vscode-prettier/vscode-prettier.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://marketplace.visualstudio.com/items/esbenp.prettier-vscode/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/prettier/prettier-vscode</projectSourceUrl>
-    <docsUrl>https://github.com/prettier/prettier-vscode/blob/master/README.md</docsUrl>
+    <docsUrl>https://github.com/prettier/prettier-vscode/blob/main/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/prettier/prettier-vscode/issues</bugTrackerUrl>
     <tags>formatter code vscode prettier</tags>
     <summary>Debug your JavaScript code in the Chrome browser, or any other target that supports the Chrome Debugger protocol</summary>
@@ -39,7 +39,7 @@
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md</releaseNotes>
+    <releaseNotes>https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
     </dependencies>


### PR DESCRIPTION
The default branch name was changed from master --> main on the source repository.  Documentation references were updated accordingly.