### PR TITLE
(gh-109) Updated vscode-go extension to reflect migration

### DIFF
--- a/automatic/vscode-go/README.md
+++ b/automatic/vscode-go/README.md
@@ -1,28 +1,27 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@f6955499323841ec9a33508345bfe5257fcfee78/icons/vscode-go.png" width="48" height="48" />Go VSCode Extension](<https://chocolatey.org/packages/vscode-go>)
 
-[![GitHub license](https://img.shields.io/github/license/microsoft/vscode-edge-debug)](https://github.com/microsoft/vscode-go/blob/master/LICENSE)
-[![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
+[![GitHub license](https://img.shields.io/github/license/golang/vscode-go)](https://github.com/golang/vscode-go/blob/master/LICENSE)
+[![Maintenance status](https://img.shields.io/badge/maintained-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Visual Studio Marketplace version](https://img.shields.io/visual-studio-marketplace/v/ms-vscode.Go?label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go)
+[![Visual Studio Marketplace version](https://img.shields.io/visual-studio-marketplace/v/golang.Go?label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=golang.Go)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/vscode-go?label=Chocolatey)](https://chocolatey.org/packages/vscode-go)
 
 This extension adds rich language support for the [Go language](https://golang.org/) to VS Code.
 
 ## Features
 
-* [Intellisense](https://github.com/microsoft/vscode-go/blob/master/README.md#intellisense)
-* [Code Navigation](https://github.com/microsoft/vscode-go/blob/master/README.md#code-navigation)
-* [Code Editing](https://github.com/microsoft/vscode-go/blob/master/README.md#code-editing)
-* [Diagnostics](https://github.com/microsoft/vscode-go/blob/master/README.md#diagnostics)
-* [Testing](https://github.com/microsoft/vscode-go/blob/master/README.md#testing)
-* [Debugging](https://github.com/microsoft/vscode-go/blob/master/README.md#debugging)
-* [Others](https://github.com/microsoft/vscode-go/blob/master/README.md#others)
+* [Intellisense](https://github.com/golang/vscode-go/blob/master/docs/features.md#intellisense)
+* [Code Navigation](https://github.com/golang/vscode-go/blob/master/docs/features.md#code-navigation)
+* [Code Editing](https://github.com/golang/vscode-go/blob/master/docs/features.md#code-editing)
+* [Diagnostics](https://github.com/golang/vscode-go/blob/master/docs/features.md#diagnostics)
+* [Testing](https://github.com/golang/vscode-go/blob/master/docs/features.md#run-and-test-in-the-editor)
+* [Debugging](https://github.com/golang/vscode-go/blob/master/README.md#debugging)
 
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@f6955499323841ec9a33508345bfe5257fcfee78/automatic/vscode-go/screenshot.png)
 
 ## Notes
 
-* Additional Go tool setup is required to use this extension so follow the instructions in [how to use this extension](https://github.com/microsoft/vscode-go/blob/master/README.md#how-to-use-this-extension)
+* Additional Go tool setup is required to use this extension so follow the [getting started](https://github.com/golang/vscode-go/blob/master/README.md#getting-started) instructions.
 * This package requires Visual Studio Code 1.41.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
 * The extension will be installed in all editions of Visual Studio Code which can be found.

--- a/automatic/vscode-go/legal/LICENSE.txt
+++ b/automatic/vscode-go/legal/LICENSE.txt
@@ -2,7 +2,8 @@
 
 The MIT License (MIT)
 
-Copyright (c) Microsoft Corporation
+Original Work Copyright (c) 2015-2020 Microsoft Corporation
+Current Work and Modifications Copyright (c) 2020-present The Go Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/automatic/vscode-go/legal/VERIFICATION.txt
+++ b/automatic/vscode-go/legal/VERIFICATION.txt
@@ -8,20 +8,20 @@ and can be verified by:
 
 1. Go to the Visual Studio Marketplace page for the extension
 
-  https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go
+  https://marketplace.visualstudio.com/items?itemName=golang.Go
 
-and download the extension ms-vscode.Go-0.14.3.vsix using the Download Extension link
+and download the extension golang.Go-0.14.4.vsix using the Download Extension link
 in the Resources section of the sidebar.
 
 Alternatively the package can be downloaded directly from
 
-  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/Go/0.14.3/vspackage
+  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/golang/vsextensions/Go/0.14.4/vspackage
 
 2. The extension can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash ms-vscode.Go-0.14.3.vsix
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f ms-vscode.Go-0.14.3.vsix
+  - Use powershell function 'Get-Filehash' - Get-Filehash golang.Go-0.14.4.vsix
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f golang.Go-0.14.4.vsix
 
   Type:     sha256
-  Checksum: 3290B6A7D4A504B253384534C0C3F3174484ADC754CBAC36140E4504AE44D84F
+  Checksum: F112E50B36495DB05FA604F85C53ACF191FAF88AB2984A7B9CC44852FB1E2DE6
 
-  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/ms-vscode.Go/license
+  File LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/golang.Go/license

--- a/automatic/vscode-go/tools/chocolateyinstall.ps1
+++ b/automatic/vscode-go/tools/chocolateyinstall.ps1
@@ -2,4 +2,4 @@
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-Install-VsCodeExtension -extensionId "$toolsDir\ms-vscode.Go-0.14.3.vsix"
+Install-VsCodeExtension -extensionId "$toolsDir\golang.Go-0.14.4.vsix"

--- a/automatic/vscode-go/tools/chocolateyuninstall.ps1
+++ b/automatic/vscode-go/tools/chocolateyuninstall.ps1
@@ -1,3 +1,3 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-Uninstall-VsCodeExtension -extensionId 'ms-vscode.Go'
+Uninstall-VsCodeExtension -extensionId 'golang.Go'

--- a/automatic/vscode-go/update.ps1
+++ b/automatic/vscode-go/update.ps1
@@ -1,8 +1,10 @@
-Import-Module au
+﻿Import-Module au
 Import-Module ..\..\scripts\vs-marketplace\VS-Marketplace.psd1
 
+$ErrorActionPreference = 'Stop'
+
 $extension = 'Go'
-$publisher = 'ms-vscode'
+$publisher = 'golang'
 
 function global:au_SearchReplace {
   @{

--- a/automatic/vscode-go/vscode-go.nuspec
+++ b/automatic/vscode-go/vscode-go.nuspec
@@ -3,38 +3,37 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vscode-go</id>
-    <version>0.14.3</version>
+    <version>0.14.4</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/vscode-go</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Go VSCode Extension</title>
-    <authors>Microsoft</authors>
-    <projectUrl>https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go</projectUrl>
+    <authors>Go Authors</authors>
+    <projectUrl>https://marketplace.visualstudio.com/items?itemName=golang.Go</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@f6955499323841ec9a33508345bfe5257fcfee78/icons/vscode-go.png</iconUrl>
-    <copyright>Copyright 2015-2019 Microsoft Corporation</copyright>
-    <licenseUrl>https://marketplace.visualstudio.com/items/ms-vscode.Go/license</licenseUrl>
+    <copyright>Copyright 2015-2020 Microsoft Corporation, Copyright 2020-Present The Go Authors</copyright>
+    <licenseUrl>https://marketplace.visualstudio.com/items/golang.Go/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/Microsoft/vscode-go</projectSourceUrl>
-    <docsUrl>https://github.com/microsoft/vscode-go/blob/master/README.md</docsUrl>
-    <bugTrackerUrl>https://github.com/Microsoft/vscode-go/issues</bugTrackerUrl>
-    <tags>go debug debugger vscode microsoft</tags>
+    <projectSourceUrl>https://github.com/golang/vscode-go</projectSourceUrl>
+    <docsUrl>https://github.com/golang/vscode-go/blob/master/README.md</docsUrl>
+    <bugTrackerUrl>https://github.com/golang/vscode-go/issues</bugTrackerUrl>
+    <tags>go debug debugger vscode vscode-go golang</tags>
     <summary>Rich Go language support for Visual Studio Code</summary>
     <description><![CDATA[This extension adds rich language support for the [Go language](https://golang.org/) to VS Code.
 
 ## Features
 
-* [Intellisense](https://github.com/microsoft/vscode-go/blob/master/README.md#intellisense)
-* [Code Navigation](https://github.com/microsoft/vscode-go/blob/master/README.md#code-navigation)
-* [Code Editing](https://github.com/microsoft/vscode-go/blob/master/README.md#code-editing)
-* [Diagnostics](https://github.com/microsoft/vscode-go/blob/master/README.md#diagnostics)
-* [Testing](https://github.com/microsoft/vscode-go/blob/master/README.md#testing)
-* [Debugging](https://github.com/microsoft/vscode-go/blob/master/README.md#debugging)
-* [Others](https://github.com/microsoft/vscode-go/blob/master/README.md#others)
+* [Intellisense](https://github.com/golang/vscode-go/blob/master/docs/features.md#intellisense)
+* [Code Navigation](https://github.com/golang/vscode-go/blob/master/docs/features.md#code-navigation)
+* [Code Editing](https://github.com/golang/vscode-go/blob/master/docs/features.md#code-editing)
+* [Diagnostics](https://github.com/golang/vscode-go/blob/master/docs/features.md#diagnostics)
+* [Testing](https://github.com/golang/vscode-go/blob/master/docs/features.md#run-and-test-in-the-editor)
+* [Debugging](https://github.com/golang/vscode-go/blob/master/README.md#debugging)
 
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@f6955499323841ec9a33508345bfe5257fcfee78/automatic/vscode-go/screenshot.png)
 
 ## Notes
 
-* Additional Go tool setup is required to use this extension so follow the instructions in [how to use this extension](https://github.com/microsoft/vscode-go/blob/master/README.md#how-to-use-this-extension)
+* Additional Go tool setup is required to use this extension so follow the [getting started](https://github.com/golang/vscode-go/blob/master/README.md#getting-started) instructions.
 * This package requires Visual Studio Code 1.41.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
 * The extension will be installed in all editions of Visual Studio Code which can be found.
@@ -44,7 +43,7 @@
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://marketplace.visualstudio.com/items/ms-vscode.Go/changelog</releaseNotes>
+    <releaseNotes>https://marketplace.visualstudio.com/items/golang.Go/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
     </dependencies>


### PR DESCRIPTION
The vscode-go extension was migrated to the official golang project.  The
extension naming and documentation needed to be updated to reflect the
migration.