### PR TITLE
(gh-123) Modify extension definitions in update script

### DIFF
--- a/automatic/vscode-live-share-audio/update.ps1
+++ b/automatic/vscode-live-share-audio/update.ps1
@@ -3,7 +3,7 @@ Import-Module ..\..\scripts\vs-marketplace\VS-Marketplace.psd1
 
 $ErrorActionPreference = 'Stop'
 
-$extension = 'vsliveshare'
+$extension = 'vsliveshare-audio'
 $publisher = 'MS-vsliveshare'
 
 function global:au_SearchReplace {


### PR DESCRIPTION
The extension definitions in the automatic update script for the
vscode-live-share extension were not correct.  They were referencing
the live share extension rather than the live share audio extension.