### PR TITLE
(gh-138) Corrected GitHub Pull Requests extension pack updater

### DIFF
--- a/automatic/vscode-pull-request-github/README.md
+++ b/automatic/vscode-pull-request-github/README.md
@@ -25,7 +25,7 @@ This extension allows you to review and manage [GitHub](https://github.com) pull
 
 ## Notes
 
-* This package requires Visual Studio Code 1.41.0 or newer.
+* This package requires Visual Studio Code 1.48.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
 * The extension will be installed in all editions of Visual Studio Code which can be found.
 * While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.

--- a/automatic/vscode-pull-request-github/legal/VERIFICATION.txt
+++ b/automatic/vscode-pull-request-github/legal/VERIFICATION.txt
@@ -10,18 +10,18 @@ and can be verified by:
 
    https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github
 
-and download the extension GitHub.vscode-pull-request-github-1.19.0.vsix using the Download Extension link
+and download the extension GitHub.vscode-pull-request-github-0.18.0.vsix using the Download Extension link
 in the Resources section of the sidebar.
 
 Alternatively the package can be downloaded directly from
 
-  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/GitHub/vsextensions/vscode-pull-request-github/1.19.0/vspackage
+  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/GitHub/vsextensions/vscode-pull-request-github/0.18.0/vspackage
 
 2. The extension can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash GitHub.vscode-pull-request-github-1.19.0.vsix
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f GitHub.vscode-pull-request-github-1.19.0.vsix
+  - Use powershell function 'Get-Filehash' - Get-Filehash GitHub.vscode-pull-request-github-0.18.0.vsix
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f GitHub.vscode-pull-request-github-0.18.0.vsix
 
   Type:     sha256
-  Checksum: D34B45CE2CA4B01E1E806359AC892F51BC0A3BB4537436519436C36052F47513
+  Checksum: 7E34E8E80A13738C1BD25E33BD1BAEDDDAB3ADDF3E10B94E776182BA7CA57183
 
   Contents of LICENSE.txt is obtained from https://github.com/microsoft/vscode-pull-request-github/blob/master/LICENSE

--- a/automatic/vscode-pull-request-github/tools/chocolateyinstall.ps1
+++ b/automatic/vscode-pull-request-github/tools/chocolateyinstall.ps1
@@ -2,4 +2,4 @@
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-Install-VsCodeExtension -extensionId "$toolsDir\GitHub.vscode-pull-request-github-1.19.0.vsix"
+Install-VsCodeExtension -extensionId "$toolsDir\GitHub.vscode-pull-request-github-0.18.0.vsix"

--- a/automatic/vscode-pull-request-github/update.ps1
+++ b/automatic/vscode-pull-request-github/update.ps1
@@ -3,8 +3,8 @@ Import-Module ..\..\scripts\vs-marketplace\VS-Marketplace.psd1
 
 $ErrorActionPreference = 'Stop'
 
-$extension = 'vscode-spring-boot'
-$publisher = 'Pivotal'
+$extension = 'vscode-pull-request-github'
+$publisher = 'GitHub'
 
 function global:au_SearchReplace {
   @{

--- a/automatic/vscode-pull-request-github/vscode-pull-request-github.nuspec
+++ b/automatic/vscode-pull-request-github/vscode-pull-request-github.nuspec
@@ -3,12 +3,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vscode-pull-request-github</id>
-    <version>1.19.0</version>
+    <version>0.18.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/vscode-pull-request-github</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>GitHub Pull Requests and Issues VSCode Extension</title>
     <authors>Microsoft</authors>
-    <projectUrl>https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio</projectUrl>
+    <projectUrl>https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@26571f0d41c79f663383da0b4ba7c65854da63c0/icons/vscode-pull-request-github.png</iconUrl>
     <copyright>Copyright 2018-2020 Microsoft Corporation</copyright>
     <licenseUrl>https://marketplace.visualstudio.com/items/GitHub.vscode-pull-request-github/license</licenseUrl>
@@ -18,7 +18,9 @@
     <bugTrackerUrl>https://github.com/Microsoft/vscode-pull-request-github/issues</bugTrackerUrl>
     <tags>github pull-requests issues vscode microsoft</tags>
     <summary>Review and manage your GitHub pull requests and issues directly in VS Code</summary>
-    <description><![CDATA[This extension allows you to review and manage [GitHub](https://github.com) pull requests and issues in Visual Studio Code.
+    <description><![CDATA[
+
+This extension allows you to review and manage [GitHub](https://github.com) pull requests and issues in Visual Studio Code.
 
 ## Features
 
@@ -37,7 +39,7 @@
 
 ## Notes
 
-* This package requires Visual Studio Code 1.41.0 or newer.
+* This package requires Visual Studio Code 1.48.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
 * The extension will be installed in all editions of Visual Studio Code which can be found.
 * While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.


### PR DESCRIPTION
The package updater for the GitHub Pull Requests and Issues VSCode
extension was pulling in a bad version which did not exist.  This was
due to an error in the name of the extension used in the update script
with a version being pulled in for a completely unrelated extension.

Corrected the extension used in the updater and ensured that version
references were aligned accordingly.