### PR TITLE
(gh-158) Use $PSScriptRoot for resource scoping

### DIFF
--- a/scripts/vs-marketplace/functions/Get-VSMarketplaceExtensionDetails.ps1
+++ b/scripts/vs-marketplace/functions/Get-VSMarketplaceExtensionDetails.ps1
@@ -226,7 +226,7 @@ Function Get-VSMarketplaceCopyrightMappings() {
   Param()
 
   try {
-      $json = Get-Content -Path "CopyrightMappings.json" -ErrorAction 'Stop' | Out-String | ConvertFrom-Json
+      $json = Get-Content -Path "$PSScriptRoot\CopyrightMappings.json" -ErrorAction 'Stop' | Out-String | ConvertFrom-Json
       $authors = @{}
       $json.Author.psobject.properties | Foreach { $authors[$_.Name] = $_.Value }
       $displayPublishers = @{}


### PR DESCRIPTION
Resource files were not being successfully located.  Included the
$PSScriptRoot in the resource prefix to support location at runtime.