### PR TITLE
(gh-162) Modified update script to remove email address

### DIFF
--- a/automatic/vscode-go-test-adapter/update.ps1
+++ b/automatic/vscode-go-test-adapter/update.ps1
@@ -45,7 +45,7 @@ function global:au_GetLatest {
   $extensionInfo = Get-VSMarketplaceExtensionDetails -Extension $extension -Publisher $publisher
 
   @{
-    Copyright      = [System.Net.WebUtility]::HtmlEncode($extensionInfo.Copyright)
+    Copyright      = $extensionInfo.Copyright -replace "\s<.*>",""
     Version        = $extensionInfo.Version
     VSCodeVersion  = $extensionInfo.VSCodeVersion
     URL32          = $extensionInfo.DownloadUrl

--- a/automatic/vscode-go-test-adapter/vscode-go-test-adapter.nuspec
+++ b/automatic/vscode-go-test-adapter/vscode-go-test-adapter.nuspec
@@ -10,7 +10,7 @@
     <authors>Ethan Reesor</authors>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=ethan-reesor.vscode-go-test-adapter</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@8b519032ce75071e44d5d46b3ea8ae89dadd8537/icons/vscode-go-test-adapter.png</iconUrl>
-    <copyright>Copyright 2020 Ethan Reesor &lt;ethan.reesor@gmail.com&gt;</copyright>
+    <copyright>Copyright 2020 Ethan Reesor</copyright>
     <licenseUrl>https://marketplace.visualstudio.com/items/ethan-reesor.vscode-go-test-adapter/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://gitlab.com/firelizzard/vscode-go-test-adapter</projectSourceUrl>

--- a/automatic/vscode-test-explorer/update.ps1
+++ b/automatic/vscode-test-explorer/update.ps1
@@ -45,7 +45,7 @@ function global:au_GetLatest {
   $extensionInfo = Get-VSMarketplaceExtensionDetails -Extension $extension -Publisher $publisher
 
   @{
-    Copyright      = [System.Net.WebUtility]::HtmlEncode($extensionInfo.Copyright)
+    Copyright      = $extensionInfo.Copyright -replace "\s<.*>",""
     Version        = $extensionInfo.Version
     VSCodeVersion  = $extensionInfo.VSCodeVersion
     URL32          = $extensionInfo.DownloadUrl

--- a/automatic/vscode-test-explorer/vscode-test-explorer.nuspec
+++ b/automatic/vscode-test-explorer/vscode-test-explorer.nuspec
@@ -10,7 +10,7 @@
     <authors>Holger Benl</authors>
     <projectUrl>https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@84caa278732a2ec09d33dae120723b2f8de96bc2/icons/vscode-test-explorer.png</iconUrl>
-    <copyright>Copyright 2018-2020 Holger Benl &lt;hbenl@evandor.de&gt;</copyright>
+    <copyright>Copyright 2018-2020 Holger Benl</copyright>
     <licenseUrl>https://marketplace.visualstudio.com/items/hbenl.vscode-test-explorer/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/hbenl/vscode-test-explorer</projectSourceUrl>


### PR DESCRIPTION
Email addresses are not valid for inclusion in a copyright element of a
Chocolatey package definition.  Modified package definitions to remove
email addresses and update scripts to ensure that they are not included
going forward.