### PR TITLE
(gh-151) Corrected extension and publisher name

### DIFF
--- a/automatic/vscode-haskell/update.ps1
+++ b/automatic/vscode-haskell/update.ps1
@@ -3,8 +3,8 @@ Import-Module ..\..\scripts\vs-marketplace\VS-Marketplace.psd1
 
 $ErrorActionPreference = 'Stop'
 
-$extension = 'haskall'
-$publisher = 'haskall'
+$extension = 'haskell'
+$publisher = 'haskell'
 
 function global:au_SearchReplace {
   @{


### PR DESCRIPTION
Both the extension and publisher naming was incorrect - 'haskall' as
opposed to 'haskell'.  This was cuasing the package updates to fail with
it not being possible to locate the extension page on the VSCode
Marketplace.

Corrected the spelling for the extension name and publisher to address
this.