### PR TITLE
(gh-178) Updated description markdown headings

### DIFF
--- a/automatic/pictus.install/pictus.install.nuspec
+++ b/automatic/pictus.install/pictus.install.nuspec
@@ -21,7 +21,7 @@
 
 Pictus is a fast, free image viewer. It is designed to be small, fast and just totally sweet. If you are content with your current photo viewer software you can still install Pictus and just let it help Windows Explorer show thumbnails for even more images.
 
-##Features
+## Features
 
 * Loads images in advance.
 * Designed for responsiveness.

--- a/automatic/pictus.portable/pictus.portable.nuspec
+++ b/automatic/pictus.portable/pictus.portable.nuspec
@@ -21,7 +21,7 @@
 
 Pictus is a fast, free image viewer. It is designed to be small, fast and just totally sweet. If you are content with your current photo viewer software you can still install Pictus and just let it help Windows Explorer show thumbnails for even more images.
 
-##Features
+## Features
 
 * Loads images in advance.
 * Designed for responsiveness.

--- a/automatic/pictus/pictus.nuspec
+++ b/automatic/pictus/pictus.nuspec
@@ -21,7 +21,7 @@
 
 Pictus is a fast, free image viewer. It is designed to be small, fast and just totally sweet. If you are content with your current photo viewer software you can still install Pictus and just let it help Windows Explorer show thumbnails for even more images.
 
-##Features
+## Features
 
 * Loads images in advance.
 * Designed for responsiveness.


### PR DESCRIPTION
Updated package descriptions to address  invalid markdown headings.
Headers in the package descriptions were missing a space between the
format descriptor and heading text.