### PR TITLE
(gh-195) Update package install script

### DIFF
--- a/automatic/dotcover-cli/tools/chocolateyInstall.ps1
+++ b/automatic/dotcover-cli/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
-$archive  = JetBrains.dotCover.CommandLineTools.2020.3.2.zip'
+$archive  = 'JetBrains.dotCover.CommandLineTools.2020.3.2.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName


### PR DESCRIPTION
The package install script is failing verification due to a syntax error
caused by a missing `'` on a string.  The string needs to be
updated to include the opening `'` to ensure the syntax is valid.