### PR TITLE
(gh-201) Modified update script to match on boundaries

### DIFF
--- a/automatic/dotcover-cli/tools/chocolateyInstall.ps1
+++ b/automatic/dotcover-cli/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
-$archive  = 'JetBrains.dotCover.CommandLineTools.2020.3.2.zip'
+$archive  = Join-Path $toolsDir 'JetBrains.dotCover.CommandLineTools.2020.3.2.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName
@@ -10,5 +10,5 @@ $unzipArgs = @{
 }
 
 Get-ChocolateyUnzip @unzipArgs
-Remove-Item $toolsPath\*.zip -ea 0
+Remove-Item $toolsDir\*.zip -ea 0
 Get-ChildItem $toolsDir -include *.exe -exclude 'dotCover.exe' -recurse  | Select-Object { New-Item "$_.ignore" -type file -force } | Out-Null

--- a/automatic/dotcover-cli/update.ps1
+++ b/automatic/dotcover-cli/update.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://data.services.jetbrains.com'
 $releases = "${domain}/products?code=DCCLT&release.type=release"
 
-$refile    = "(\/|'|\s'|e\s|\s)(J.+zip)"
+$refile    = "\b(\/|'|\s'|e\s|\s)(J.+zip)"
 $reversion = '(-v)(\d+\.\d\.*\d*)'
 
 function global:au_BeforeUpdate {


### PR DESCRIPTION
Package updates were incorrectly modifying the install script due to
excessive matching on the regular expression.  The expression needed to
be updated to match on word boundaries to support the match within the
string of the package version only to preserve the correct syntax in the
update script.