### PR TITLE
(gh-209) Fix CLOC Automatic Update

### DIFF
--- a/automatic/cloc/update.ps1
+++ b/automatic/cloc/update.ps1
@@ -41,8 +41,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-  $urls           = $download_page.links | where-object href -match $reurl | select-object -expand href | foreach-object { $domain + $_ }
-  $url            = $urls -match $re | select-object -first 1
+  $url            = $download_page.links | where-object href -match $refile | select-object -first 1 -expand href | foreach-object { $domain + $_ }
   $urlSegmentSize = $([System.Uri]$url).Segments.Length
   $filename       = $([System.Uri]$url).Segments[$urlSegmentSize - 1]
 


### PR DESCRIPTION
The AU automatic update for the CLOC package was failing due to a
mismatch in the regular expression extracting the url.  An empty URL was
being extracted which ensured that the version number was not able to be
extracted.  The lack of the version number was breaking the update.

Corrected the URL extraction to provide a valid URL and ensure the
availability of the version number.