### PR TITLE
(gh-213) Correct Prime95 Bugtracker Url

### DIFF
--- a/automatic/prime95/README.md
+++ b/automatic/prime95/README.md
@@ -28,11 +28,12 @@ To have choco remember parameters on upgrade, be sure to set `choco feature enab
 
 ## Notes
 
-* If support for 32-bit Windows XP is required use the legacy version [Prime95 30.3.6](https://chocolatey.org/packages/prime95/30.3.6).
+* If support for 32-bit Windows XP is required use the legacy version [Prime95 29.8.6](https://chocolatey.org/packages/prime95/29.8.6).
 
   ```powershell
-  choco install prime95 --version 30.3.6
-  choco pin pin add -n=bluejprime95 --version 30.3.6
+  choco install prime95 --version 29.8.6
+  choco pin pin add -n=prime95 --version 29.8.6
   ```
+
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/prime95/prime95.nuspec
+++ b/automatic/prime95/prime95.nuspec
@@ -15,7 +15,6 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://www.mersenne.org/download/#source</projectSourceUrl>
     <docsUrl>http://www.mersenne.org/download/readme.txt</docsUrl>
-    <bugTrackerUrl>mailto:woltman@alum.mit.edu</bugTrackerUrl>
     <mailingListUrl>http://www.mersenneforum.org/</mailingListUrl>
     <tags>prime prime95 mersenne stress stress-test burn-in gimps</tags>
     <summary>Find Mersenne Prime numbers or stress test systems</summary>
@@ -47,7 +46,7 @@ To have choco remember parameters on upgrade, be sure to set `choco feature enab
 
   ```powershell
   choco install prime95 --version 29.8.6
-  choco pin pin add -n=bluejprime95 --version 29.8.6
+  choco pin pin add -n=prime95 --version 29.8.6
   ```
 
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).

--- a/automatic/prime95/update.ps1
+++ b/automatic/prime95/update.ps1
@@ -17,7 +17,7 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "(\d+\.\d+.\d+)" = "$($Latest.Version)"
+      "(v)(\d+\.\d+.\d+)" = "`${1}$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt" = @{


### PR DESCRIPTION
The Prime95 package was failing validation due to an invalid URL in the
Bugtracker element. The element is currently an email address which is
not supported by the package validator.  Removed the Bugtracker element
as there is no alternative to email available - Prime95 does not have a
public bug tracker.

There was also an issue with the automatic update picking up unintended
additional version strings.  Reverted these version strings to the
correctvlegacy version and modified the update script to ensure that
they would not be picke up in future.