### PR TITLE
(gh-152) SQL Server Compact Package Updates

### DIFF
--- a/manual/mssqlserver-compact4.0/README.md
+++ b/manual/mssqlserver-compact4.0/README.md
@@ -2,7 +2,6 @@
 
 [![Software License](https://img.shields.io/badge/license-proprietary-lightgrey)](https://www.microsoft.com/download/details.aspx?id=30709)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
-[![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
 [![Software version](https://img.shields.io/badge/Source-v4.0.8876.1-blue.svg)](https://www.microsoft.com/download/details.aspx?id=30709)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/go-fonts?label=Chocolatey)](https://chocolatey.org/packages/mssqlserver-compact4.0)
 
@@ -49,7 +48,7 @@ specified the install will default to English.
   * zh-CN - Chinese (Simplified) - `--params '"/language=zh-CN"'`
   * zh-TW - Chinese (Tradition) - `--params '"/language=gz-TW"'`
 
-For example: `choco install mssqlserver-compact4.0 --params '"/language=fr"'` to install the package with French
+For example: `choco install mssqlserver-compact4.0 --params '"/language=fr"'` to install the French version of the package
 
 ## Notes
 

--- a/manual/mssqlserver-compact4.0/legal/VERIFICATION.txt
+++ b/manual/mssqlserver-compact4.0/legal/VERIFICATION.txt
@@ -6,7 +6,7 @@ in verifying that this package's contents are trustworthy.
 The installers have been downloaded from the official distribution and can
 be verified by:
 
-1. Go to the software distribtion page
+1. Go to the software distribution page
 
   https://www.microsoft.com/download/details.aspx?id=30709
 
@@ -14,6 +14,7 @@ and retrieve the SSCERuntime files by selecting the relevant language in the
 dropdown followed by the download button and file selection.
 
 2. The archives can be validated by comparing checksums
+
   - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 SSCERuntime_x86-CHS.exe
   - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f SSCERuntime_x86-CHS.exe
 
@@ -55,7 +56,6 @@ dropdown followed by the download button and file selection.
   File:     SSCERuntime_x86-ESN.exe
   Type:     sha256
   Checksum: DE3D25C5EDB5CD5126121B92735CF974E90FDE471A4026B2B16321F15682F5FC
-
 
   - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 SSCERuntime_x86-FRA.exe
   - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f SSCERuntime_x86-FRA.exe
@@ -154,7 +154,6 @@ dropdown followed by the download button and file selection.
   File:     SSCERuntime_x64-ESN.exe
   Type:     sha256
   Checksum: 3FB0C8BCF3C22F37A5A3BB4F4A8537149AAEA038442D1FBCBDA4780912E913FC
-
 
   - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 SSCERuntime_x64-FRA.exe
   - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f SSCERuntime_x64-FRA.exe

--- a/manual/mssqlserver-compact4.0/mssqlserver-compact4.0.nuspec
+++ b/manual/mssqlserver-compact4.0/mssqlserver-compact4.0.nuspec
@@ -62,7 +62,7 @@ specified the install will default to English.
   * zh-CN - Chinese (Simplified) - `--params '"/language=zh-CN"'`
   * zh-TW - Chinese (Tradition) - `--params '"/language=gz-TW"'`
 
-For example: `choco install mssqlserver-compact4.0 --params '"/language=fr"'` to install the package with French
+For example: `choco install mssqlserver-compact4.0 --params '"/language=fr"'` to install the French version of the package
 
 ## Notes
 

--- a/manual/mssqlserver-compact4.0/tools/chocolateyInstall.ps1
+++ b/manual/mssqlserver-compact4.0/tools/chocolateyInstall.ps1
@@ -14,28 +14,30 @@ if ((Get-ProcessorBits 32) -eq 'true') {
   Write-Error 'Unsupported CPU architecture'
 }
 
-class Language {
-    [string]$Code
-    [string]$Name
-    [string]$mapping
+add-type @"
+public struct Language {
+   public string Code;
+   public string Name;
+   public string Mapping;
 }
+"@
 
 $languages =  @{
-    'br'    = [Language] @{ Code='br';    Name = 'Brazil (Portuguese)';   Mapping = 'PTB' }
-    'cz'    = [Language] @{ Code='cz';    Name = 'Czech';                 Mapping = 'CSY' }
-    'de'    = [Language] @{ Code='de';    Name = 'German';                Mapping = 'DEU' }
-    'en'    = [Language] @{ Code='en';    Name = 'English';               Mapping = 'ENU' }
-    'es'    = [Language] @{ Code='es';    Name = 'Spanish';               Mapping = 'ESN' }
-    'fr'    = [Language] @{ Code='fr';    Name = 'French';                Mapping = 'FRA' }
-    'it'    = [Language] @{ Code='it';    Name = 'Italian';               Mapping = 'ITA' }
-    'ja'    = [Language] @{ Code='ja';    Name = 'Japanese';              Mapping = 'JPN' }
-    'ko'    = [Language] @{ Code='ko';    Name = 'Korean';                Mapping = 'KOR' }
-    'pl'    = [Language] @{ Code='pl';    Name = 'Polish';                Mapping = 'PLK' }
-    'ru'    = [Language] @{ Code='ru';    Name = 'Russian';               Mapping = 'RUS' }
-    'tr'    = [Language] @{ Code='tr';    Name = 'Turkish';               Mapping = 'TRK' }
-    'zh'    = [Language] @{ Code='zh';    Name = 'Chinese';               Mapping = 'CHS' }
-    'zh-CN' = [Language] @{ Code='zh-CN'; Name = 'Chinese (Simplified)';  Mapping = 'CHS' }
-    'zh-TW' = [Language] @{ Code='zh-TW'; Name = 'Chinese (Traditional)'; Mapping = 'CHT' }
+    'br'    = [Language] @{ Code='br';    Name = 'Brazilian (Portuguese)';   Mapping = 'PTB' }
+    'cz'    = [Language] @{ Code='cz';    Name = 'Czech';                    Mapping = 'CSY' }
+    'de'    = [Language] @{ Code='de';    Name = 'German';                   Mapping = 'DEU' }
+    'en'    = [Language] @{ Code='en';    Name = 'English';                  Mapping = 'ENU' }
+    'es'    = [Language] @{ Code='es';    Name = 'Spanish';                  Mapping = 'ESN' }
+    'fr'    = [Language] @{ Code='fr';    Name = 'French';                   Mapping = 'FRA' }
+    'it'    = [Language] @{ Code='it';    Name = 'Italian';                  Mapping = 'ITA' }
+    'ja'    = [Language] @{ Code='ja';    Name = 'Japanese';                 Mapping = 'JPN' }
+    'ko'    = [Language] @{ Code='ko';    Name = 'Korean';                   Mapping = 'KOR' }
+    'pl'    = [Language] @{ Code='pl';    Name = 'Polish';                   Mapping = 'PLK' }
+    'ru'    = [Language] @{ Code='ru';    Name = 'Russian';                  Mapping = 'RUS' }
+    'tr'    = [Language] @{ Code='tr';    Name = 'Turkish';                  Mapping = 'TRK' }
+    'zh'    = [Language] @{ Code='zh';    Name = 'Chinese';                  Mapping = 'CHS' }
+    'zh-CN' = [Language] @{ Code='zh-CN'; Name = 'Chinese (Simplified)';     Mapping = 'CHS' }
+    'zh-TW' = [Language] @{ Code='zh-TW'; Name = 'Chinese (Traditional)';    Mapping = 'CHT' }
 }
 
 $pp = Get-PackageParameters


### PR DESCRIPTION
Minor updates to the SQL Server Compact package:
* modified the grammar used for the language example, removed the CI
build status link given the package is manual
* updated formatting in the verification instructions
* amended the install script to use a struct versus class for compatibility
with earlier Powershell versions