### PR TITLE
(gh-248) Ensure correct version resolution on update

### DIFF
--- a/automatic/beekeeper-studio.install/README.md
+++ b/automatic/beekeeper-studio.install/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/beekeeper-studio/beekeeper-studio)](https://github.com/beekeeper-studio/beekeeper-studio/blob/master/LICENSE.md)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-1.9.4-blue.svg)](https://github.com/beekeeper-studio/beekeeper-studio/releases/tag/v1.9.4)
+[![Software version](https://img.shields.io/badge/Source-v1.9.4-blue.svg)](https://github.com/beekeeper-studio/beekeeper-studio/releases/tag/v1.9.4)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/beekeeper-studio.install?label=Chocolatey)](https://chocolatey.org/packages/beekeeper-studio.install)
 
 [Beekeeper Studio is a free and open source SQL editor and database manager.

--- a/automatic/beekeeper-studio.install/update.ps1
+++ b/automatic/beekeeper-studio.install/update.ps1
@@ -1,54 +1,25 @@
-﻿import-module au
+﻿. $PSScriptRoot\..\beekeeper-studio\update.ps1
 
 $ErrorActionPreference = 'STOP'
 
-$domain   = 'https://github.com'
-$releases = "${domain}/beekeeper-studio/beekeeper-studio/releases/latest"
-
-$re64      = '(B.+Setup.+\.exe)'
-$reversion = '(\/v|-)(?<Version>([\d]+\.[\d]+\.[\d]+))'
-
 function global:au_BeforeUpdate {
+  $Latest.FileName64 = "$($Latest.FileNameInstall)"
+  $Latest.Url64      = "$($Latest.UrlInstall)"
+
   Get-RemoteFiles -Purge -NoSuffix
 }
 
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
-    }
-
-    "$($Latest.PackageName).nuspec" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "`${1}$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "(\/v.+|\s)$($re64)"  = "`${1}$($Latest.Filename64)"
-      "(Checksum64:\s)(.+)" = "`${1}$($Latest.Checksum64)"
-      "$($reversion)"       = "`${1}$($Latest.Version)"
+      "$($reInstall)"        = "$($Latest.FileName64)"
+      "$($reVersion)"        = "`${1}$($Latest.Version)"
+      "(Checksum64:\s*)(.+)" = "`${1}$($Latest.Checksum64)"
     }
-
-    ".\tools\chocolateyinstall.ps1" = @{
-      "($re64)" = "$($Latest.FileName64)"
-    }
-  }
-}
-
-function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
-  $urls = $download_page.links | where-object href -match $reurl | select-object -expand href | foreach-object { $domain + $_ }
-
-  $url64 = $urls -match $re64 | select-object -first 1
-  $url64SegmentSize = $([System.Uri]$url64).Segments.Length
-  $filename64 = $([System.Uri]$url64).Segments[$url64SegmentSize - 1]
-
-  $url64 -match $reversion
-  $version = $Matches.Version
-
-  return @{
-    FileName64 = $filename64
-    Url64      = $url64
-    Version    = $version
   }
 }
 

--- a/automatic/beekeeper-studio.portable/README.md
+++ b/automatic/beekeeper-studio.portable/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/beekeeper-studio/beekeeper-studio)](https://github.com/beekeeper-studio/beekeeper-studio/blob/master/LICENSE.md)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-1.9.4-blue.svg)](https://github.com/beekeeper-studio/beekeeper-studio/releases/tag/v1.9.4)
+[![Software version](https://img.shields.io/badge/Source-v1.9.4-blue.svg)](https://github.com/beekeeper-studio/beekeeper-studio/releases/tag/v1.9.4)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/beekeeper-studio.portable?label=Chocolatey)](https://chocolatey.org/packages/beekeeper-studio.portable)
 
 [Beekeeper Studio is a free and open source SQL editor and database manager.

--- a/automatic/beekeeper-studio.portable/update.ps1
+++ b/automatic/beekeeper-studio.portable/update.ps1
@@ -1,58 +1,25 @@
-﻿import-module au
+﻿. $PSScriptRoot\..\beekeeper-studio\update.ps1
 
 $ErrorActionPreference = 'STOP'
 
-$domain   = 'https://github.com'
-$releases = "${domain}/beekeeper-studio/beekeeper-studio/releases/latest"
-
-$re64      = '(B.+portable\.exe)'
-$reversion = '(\/v|-)(?<Version>([\d]+\.[\d]+\.[\d]+))'
-
 function global:au_BeforeUpdate {
+  $Latest.FileName64 = "$($Latest.FileNamePortable)"
+  $Latest.Url64      = "$($Latest.UrlPortable)"
+
   Get-RemoteFiles -Purge -NoSuffix
 }
 
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
-    }
-
-    "$($Latest.PackageName).nuspec" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "`${1}$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "(\/v.+|\s)$($re64)"  = "`${1}$($Latest.Filename64)"
-      "(Checksum64:\s)(.+)" = "`${1}$($Latest.Checksum64)"
-      "$($reversion)"       = "`${1}$($Latest.Version)"
+      "$($rePortable)"       = "$($Latest.FileName64)"
+      "$($reVersion)"        = "`${1}$($Latest.Version)"
+      "(Checksum64:\s*)(.+)" = "`${1}$($Latest.Checksum64)"
     }
-
-    ".\tools\chocolateyinstall.ps1" = @{
-      "(')($re64)" = "`${1}$($Latest.FileName64)"
-    }
-
-    ".\tools\chocolateyuninstall.ps1" = @{
-      "(')($re64)" = "`${1}$($Latest.FileName64)"
-    }
-  }
-}
-
-function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
-  $urls = $download_page.links | where-object href -match $reurl | select-object -expand href | foreach-object { $domain + $_ }
-
-  $url64 = $urls -match $re64 | select-object -first 1
-  $url64SegmentSize = $([System.Uri]$url64).Segments.Length
-  $filename64 = $([System.Uri]$url64).Segments[$url64SegmentSize - 1]
-
-  $url64 -match $reversion
-  $version = $Matches.Version
-
-  return @{
-    FileName64 = $filename64
-    Url64      = $url64
-    Version    = $version
   }
 }
 

--- a/automatic/beekeeper-studio/README.md
+++ b/automatic/beekeeper-studio/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/beekeeper-studio/beekeeper-studio)](https://github.com/beekeeper-studio/beekeeper-studio/blob/master/LICENSE.md)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-1.9.4-blue.svg)](https://github.com/beekeeper-studio/beekeeper-studio/releases/tag/v1.9.4)
+[![Software version](https://img.shields.io/badge/Source-v1.9.4-blue.svg)](https://github.com/beekeeper-studio/beekeeper-studio/releases/tag/v1.9.4)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/beekeeper-studio?label=Chocolatey)](https://chocolatey.org/packages/beekeeper-studio)
 
 [Beekeeper Studio is a free and open source SQL editor and database manager.

--- a/automatic/kui/kui.nuspec
+++ b/automatic/kui/kui.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://kui.tools</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@ac9e0ef462b93905584b248422198303de1a4823/icons/kui.png</iconUrl>
     <copyright>Kui Contributors</copyright>
-    <licenseUrl>https://github.com/beekeeper-studio/beekeeper-studio/blob/master/LICENSE.md</licenseUrl>
+    <licenseUrl>https://github.com/IBM/kui/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/IBM/kui</projectSourceUrl>
     <docsUrl>https://github.com/IBM/kui/wiki</docsUrl>

--- a/automatic/kui/update.ps1
+++ b/automatic/kui/update.ps1
@@ -9,7 +9,6 @@ $re64      = '(K.+win32-x64\.zip)'
 $reversion = '(v)(?<Version>([\d]+\.[\d]+\.[\d]+))'
 
 function global:au_BeforeUpdate {
-  Write-Host('downloading file')
   Get-RemoteFiles -Purge -NoSuffix
 }
 
@@ -33,8 +32,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-  $urls       = $downloadPage.links | where-object href -match $reurl | select-object -expand href | foreach-object { $domain + $_ }
-  $url64      = $urls -match $re64 | select-object -first 1
+  $url64      = $downloadPage.links | where-object href -match $re64 | select-object -expand href | select-object -first 1 | foreach-object { $domain + $_ }
   $filename64 = $url64 -split '/' | select-object -last 1
 
   $version = $downloadPage.Content -match $reversion | foreach-object { $Matches.Version }
@@ -46,4 +44,4 @@ function global:au_GetLatest {
   }
 }
 
-update -ChecksumFor none -NoCheckUrl -NoReadme
+update -ChecksumFor none -NoReadme

--- a/automatic/mongodb-shell/README.md
+++ b/automatic/mongodb-shell/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/mongodb-js/mongosh)](https://github.com/mongodb-js/mongosh/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/version-0.7.7-blue)](https://github.com/mongodb-js/mongosh/releases/tag/v0.7.7)
+[![Software version](https://img.shields.io/badge/version-v0.7.7-blue)](https://github.com/mongodb-js/mongosh/releases/tag/v0.7.7)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/mongodb-shell?label=Chocolatey)](https://chocolatey.org/packages/mongodb-shell)
 
 The [MongoDB Shell](https://www.mongodb.com/products/shell) lets you connect to MongoDB to work with

--- a/automatic/sd-cli/README.md
+++ b/automatic/sd-cli/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/chmln/sd)](https://github.com/chmln/sd/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/version-0.7.5-blue)](https://github.com/chmln/sd/releases/tag/v0.7.5)
+[![Software version](https://img.shields.io/badge/version-v0.7.5-blue)](https://github.com/chmln/sd/releases/tag/v0.7.5)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/sd-search-displace?label=Chocolatey)](https://chocolatey.org/packages/sd-cli)
 
 `sd` is an intuitive find and replace CLI.

--- a/automatic/sd-cli/update.ps1
+++ b/automatic/sd-cli/update.ps1
@@ -3,7 +3,10 @@ import-module au
 $ErrorActionPreference = 'STOP'
 
 $domain   = 'https://github.com'
-$releases = "${domain}//chmln/sd/releases/latest"
+$releases = "${domain}/chmln/sd/releases/latest"
+
+$re64      = '(sd\..+-windows-.+zip)'
+$reVersion = "(v|')(?<Version>([\d]+\.[\d]+\.[\d]+))"
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -12,33 +15,39 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "([\d]+\.[\d]+\.[\d]+)" = "$($Latest.Version)"
+      "$($reVersion)" = "`${1}$($Latest.Version)"
+    }
+
+    ".\update.ps1" = @{
+      "$($reVersion)" = "`${1}$($Latest.Version)"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "(\s')(sd.+64.+\.zip)" = "`${1}$($Latest.Filename64)"
+      "$re64" = "$($Latest.Filename64)"
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "(sd\..+-windows-.+zip)"     = "$($Latest.Filename64)"
-      "(\/v)([\d]+\.[\d]+\.[\d]+)" = "`${1}$($Latest.Version)"
-      "(Checksum:\s)(.+)"          = "`${1}$($Latest.Checksum64)"
+      "$re64"              = "$($Latest.Filename64)"
+      "$reVersion"         = "`${1}$($Latest.Version)"
+      "(Checksum:\s*)(.+)" = "`${1}$($Latest.Checksum64)"
     }
   }
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-  $reurl = '(sd.+-windows-.+zip)'
-  $reversion = '(\/v(?<Version>([\d]+\.[\d]+\.[\d]+))\/)'
+  $url64      = $downloadPage.links | where-object href -match $re64 | select-object -expand  href | select-object -first 1 | foreach-object { $domain + $_ }
+  $filename64 = $url64 -split '/' | select-object -last 1
 
-  $url64 = $download_page.links | where-object href -match $reurl | select-object -expand  href | select-object -first 1 | foreach-object { $domain + $_ }
-  $url64SegmentSize = $([System.Uri]$url64).Segments.Length
-  $filename64 = $([System.Uri]$url64).Segments[$url64SegmentSize - 1]
+  $version = $url64 -match $reVersion | foreach-object { $Matches.Version }
 
-  $url64 -match $reversion
-  $version = $Matches.Version
+  # windows binaries are not released for all versions of this package so populate $version with the current version if
+  # there are no windows binaries available.  The nuspec has not been parsed at this stage so the current version is not
+  # available in the environment - hardcode here and use the package update process to rewrite
+  if ([string]::IsNullOrWhiteSpace($version)) {
+    $version = '0.7.5'
+  }
 
   return @{
     Filename64 = $filename64

--- a/automatic/tldr-plusplus/README.md
+++ b/automatic/tldr-plusplus/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/isacikgoz/tldr)](https://github.com/isacikgoz/tldr/blob/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-0.6.1-blue.svg)](https://github.com/isacikgoz/tldr/releases/tag/v0.6.1)
+[![Software version](https://img.shields.io/badge/Source-v0.6.1-blue.svg)](https://github.com/isacikgoz/tldr/releases/tag/v0.6.1)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/tldr-plusplus?label=Chocolatey)](https://chocolatey.org/packages/tldr-plusplus)
 
 Interactive tldr client.

--- a/automatic/watchman/README.md
+++ b/automatic/watchman/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/facebook/watchman)](https://github.com/facebook/watchman/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/source-2021.01.11.00-blue.svg)](https://github.com/facebook/watchman/releases/tag/v2021.01.11.00)
+[![Software version](https://img.shields.io/badge/source-v2021.01.11.00-blue.svg)](https://github.com/facebook/watchman/releases/tag/v2021.01.11.00)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/watchman?label=Chocolatey)](https://chocolatey.org/packages/watchman)
 
 Watchman exists to watch files and record when they change. It can also trigger actions (such as

--- a/automatic/watchman/tools/chocolateyinstall.ps1
+++ b/automatic/watchman/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
   Write-Error -Message "32-bit version of Watchman not available" -Category ResourceUnavailable


### PR DESCRIPTION
A number of packages were reporting errors on checking for updates - the
correct versions were not being resolved on update checks.  There were
2 separate categories here - handling of updates for packages where no
windows version was provided and errors in the matching of the URLs on
the download page for version determination.

The pacakges sd-cli, tldr-plusplus amd watchman were in category 1 while
beekeeper-studio, kui and mondodb-shell were in category 2.

Updated handling or matching to deal with each of these scenarios
cleanly.