### PR TITLE
(gh-250) Flashpoint package updates

### DIFF
--- a/automatic/flashpoint-core/README.md
+++ b/automatic/flashpoint-core/README.md
@@ -25,7 +25,7 @@ The following package parameter can be set:
 * `/AddToDesktop` - this puts a shortcut on your desktop to Flashpoint.
 
 These parameters can be passed to the installer with the use of `--params`.
-For example: `--params '"/AddToDesktop"'`.
+For example: `--params "/AddToDesktop"`.
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 

--- a/automatic/flashpoint-core/flashpoint-core.nuspec
+++ b/automatic/flashpoint-core/flashpoint-core.nuspec
@@ -40,7 +40,7 @@ The following package parameter can be set:
 * `/AddToDesktop` - this puts a shortcut on your desktop to Flashpoint.
 
 These parameters can be passed to the installer with the use of `--params`.
-For example: `--params '"/AddToDesktop"'`.
+For example: `--params "/AddToDesktop"`.
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 

--- a/automatic/flashpoint-core/tools/chocolateyBeforeModify.ps1
+++ b/automatic/flashpoint-core/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,8 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$desktopPath  = [Environment]::GetFolderPath("Desktop")
+$shortcutPath = Join-Path $desktopPath 'Flashpoint Core.lnk'
+
+if (Test-Path $shortcutPath) {
+  Remove-Item -Path $shortcutPath -Force | Out-Null
+}

--- a/automatic/flashpoint-core/tools/chocolateyInstall.ps1
+++ b/automatic/flashpoint-core/tools/chocolateyInstall.ps1
@@ -1,10 +1,11 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
+$toolsDir   = (Split-Path -parent $MyInvocation.MyCommand.Definition)
+$installDir = Join-Path (Get-ToolsLocation) $env:ChocolateyPackageName
 
 $packageArgs = @{
   PackageName   = $env:ChocolateyPackageName
-  UnzipLocation = $toolsDir
+  UnzipLocation = $installDir
   Url           = 'https://bluemaxima.org/flashpoint/downloads/../Flashpoint%20Core%209.7z'
   Checksum      = 'ab929031af7d872e9bca0f9146bcc165a15b8a17a4e56786e53be061be3d7f16'
   ChecksumType  = 'sha256'
@@ -12,7 +13,7 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage @packageArgs
 
-$files = Get-ChildItem $toolsDir -include *.exe -recurse
+$files = Get-ChildItem $installDir -include *.exe -recurse
 
 foreach ($file in $files) {
   New-Item "$file.ignore" -type file -force | Out-Null
@@ -42,18 +43,18 @@ Install-Binfile -Name 'Flashpoint' -Path $launchScript -UseStart
 # and Chocolatey seems to have an issue with the uninstall of a package containing a directory
 # where the ReadOnly attribute is set
 
-Get-ChildItem $toolsDir -Recurse -Force -ErrorAction SilentlyContinue | Where-Object {
+Get-ChildItem $installDir -Recurse -Force -ErrorAction SilentlyContinue | Where-Object {
   $_.PSIsContainer -and $_.Attributes -match "ReadOnly" } | foreach-object { $_.Attributes="" }
 
 $pp = Get-PackageParameters
 
 if ($pp.AddToDesktop) {
   $desktopPath  = [Environment]::GetFolderPath("Desktop")
-  $shortcutPath = Join-Path $desktopPath $applicationBinary.ReplaceEnd($executable.Extension, '.lnk')
+  $shortcutPath = Join-Path $desktopPath 'Flashpoint Core.lnk'
 
   $shortcutArgs = @{
     ShortcutFilePath = $shortcutPath
-    TargetPath       = $applictionBinary
+    TargetPath       = $applicationBinary
     WorkingDirectory = $workingDirectory
   }
 

--- a/automatic/flashpoint-core/update.ps1
+++ b/automatic/flashpoint-core/update.ps1
@@ -5,8 +5,8 @@ $ErrorActionPreference = 'STOP'
 $releases = 'https://bluemaxima.org/flashpoint/downloads/'
 
 $reCoreUrl     = 'F.+Core.+\.7z$'
-$reCoreVersion = '>F.+Core\s(?<Version>(\d\.\d))<'
-$reversion     = '(?<Version>(\d+\.\d))'
+$reCoreVersion = '>F.+Core\s(?<Version>(\d+\.\d+))<'
+$reVersion     = '(?<Version>(\d+\.\d+))'
 
 function global:au_BeforeUpdate {
   $Latest.Checksum = Get-RemoteChecksum $Latest.Url
@@ -15,12 +15,16 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "(http.*\.7z)"            = "$($Latest.Url)"
+      '(http.*\.7z)'            = "$($Latest.Url)"
       "(Checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum)'"
+    }
+
+    ".\tools\chocolateyUninstall.ps1" = @{
+      '(Fl.+\.7z)' = "$($Latest.Archive)"
     }
   }
 }
@@ -29,12 +33,14 @@ function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
   $urlCore = $downloadPage.links | where-object href -match $reCoreUrl | select-object -expand href | foreach-object { $releases + $_ }
+  $archive = ($urlCore.split('/') | select-object -last 1) -replace '%20',' '
   $version = $downloadPage.Content -match $reCoreVersion | foreach-object { $Matches.Version }
 
   return @{
+    Archive = $archive
     Url     = $urlCore
     Version = $version
   }
 }
 
-update -ChecksumFor none -NoReadme -NoCheckUrl
+update -ChecksumFor none -NoReadme

--- a/automatic/flashpoint-infinity/README.md
+++ b/automatic/flashpoint-infinity/README.md
@@ -25,7 +25,7 @@ The following package parameter can be set:
 * `/AddToDesktop` - this puts a shortcut on your desktop to Flashpoint.
 
 These parameters can be passed to the installer with the use of `--params`.
-For example: `--params '"/AddToDesktop"'`.
+For example: `--params "/AddToDesktop"`.
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 

--- a/automatic/flashpoint-infinity/flashpoint-infinity.nuspec
+++ b/automatic/flashpoint-infinity/flashpoint-infinity.nuspec
@@ -40,7 +40,7 @@ The following package parameter can be set:
 * `/AddToDesktop` - this puts a shortcut on your desktop to Flashpoint.
 
 These parameters can be passed to the installer with the use of `--params`.
-For example: `--params '"/AddToDesktop"'`.
+For example: `--params "/AddToDesktop"`.
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 

--- a/automatic/flashpoint-infinity/tools/chocolateyBeforeModify.ps1
+++ b/automatic/flashpoint-infinity/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,8 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$desktopPath  = [Environment]::GetFolderPath("Desktop")
+$shortcutPath = Join-Path $desktopPath 'Flashpoint Infinity.lnk'
+
+if (Test-Path $shortcutPath) {
+  Remove-Item -Path $shortcutPath -Force | Out-Null
+}

--- a/automatic/flashpoint-infinity/tools/chocolateyInstall.ps1
+++ b/automatic/flashpoint-infinity/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
 $packageArgs = @{
   PackageName   = $env:ChocolateyPackageName
-  UnzipLocation = $toolsDir
+  UnzipLocation = Join-Path (Get-ToolsLocation) $env:ChocolateyPackageName
   Url           = 'https://bluemaxima.org/flashpoint/downloads/../Flashpoint%209.0%20Infinity.exe'
   Checksum      = 'fba50092c763f9e13d877e3fa861fa9426332bc51298a8bf2174b536bb43514f'
   ChecksumType  = 'sha256'
@@ -12,7 +12,7 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage @packageArgs
 
-$files = Get-ChildItem $toolsDir -include *.exe -recurse
+$files = Get-ChildItem $packageArgs.UnzipLocation -include *.exe -recurse
 
 foreach ($file in $files) {
   New-Item "$file.ignore" -type file -force | Out-Null
@@ -42,18 +42,18 @@ Install-Binfile -Name 'Flashpoint' -Path $launchScript -UseStart
 # and Chocolatey seems to have an issue with the uninstall of a package containing a directory
 # where the ReadOnly attribute is set
 
-Get-ChildItem $toolsDir -Recurse -Force -ErrorAction SilentlyContinue | Where-Object {
+Get-ChildItem $workingDirectory -Recurse -Force -ErrorAction SilentlyContinue | Where-Object {
   $_.PSIsContainer -and $_.Attributes -match "ReadOnly" } | foreach-object { $_.Attributes="" }
 
 $pp = Get-PackageParameters
 
 if ($pp.AddToDesktop) {
   $desktopPath  = [Environment]::GetFolderPath("Desktop")
-  $shortcutPath = Join-Path $desktopPath $applicationBinary.ReplaceEnd($executable.Extension, '.lnk')
+  $shortcutPath = Join-Path $desktopPath 'Flashpoint Infinity.lnk'
 
   $shortcutArgs = @{
     ShortcutFilePath = $shortcutPath
-    TargetPath       = $applictionBinary
+    TargetPath       = $applicationBinary
     WorkingDirectory = $workingDirectory
   }
 

--- a/automatic/flashpoint-infinity/tools/chocolateyUninstall.ps1
+++ b/automatic/flashpoint-infinity/tools/chocolateyUninstall.ps1
@@ -1,13 +1,14 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$launchScript = "Flashpoint.cmd"
+Uninstall-BinFile -Name 'Flashpoint' -Path 'Flashpoint.cmd'
 
-Uninstall-BinFile -Name 'Flashpoint' -Path $launchScript
-
-$desktopPath  = [Environment]::GetFolderPath("Desktop")
-$executable   = Get-ChildItem $toolsDir -Include 'Flashpoint.exe' -Recurse
-$shortcutPath = Join-Path $desktopPath $executable.Name.Replace($executable.Extension, '.lnk')
-
-if (Test-Path $shortcutPath) {
-  Remove-Item -Path $shortcutPath -Force | Out-Null
+$packageArgs = @{
+  PackageName = $env:ChocolateyPackageName
+  ZipFileName = 'Flashpoint 9.0 Infinity.exe'
 }
+
+UnInstall-ChocolateyZipPackage @packageArgs
+
+$installDir = Join-Path (Get-ToolsLocation) $env:ChocolateyPackageName
+
+Remove-Item $installDir -Force  -Recurse -ErrorAction SilentlyContinue | Out-Null

--- a/automatic/flashpoint-launcher/README.md
+++ b/automatic/flashpoint-launcher/README.md
@@ -12,6 +12,17 @@ which is a web preservation project.
 
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@71d741b5e9171786eff61aea63d42c7c6ef286c6/automatic/flashpoint-launcher/screenshot.png)
 
+## Package Parameters
+
+The following package parameter can be set:
+
+* `/AddToDesktop` - this puts a shortcut on your desktop to Flashpoint.
+
+These parameters can be passed to the installer with the use of `--params`.
+For example: `--params "/AddToDesktop"`.
+
+To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
+
 ## Notes
 
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).

--- a/automatic/flashpoint-launcher/flashpoint-launcher.nuspec
+++ b/automatic/flashpoint-launcher/flashpoint-launcher.nuspec
@@ -27,6 +27,17 @@ project.
 
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@71d741b5e9171786eff61aea63d42c7c6ef286c6/automatic/flashpoint-launcher/screenshot.png))
 
+## Package Parameters
+
+The following package parameter can be set:
+
+* `/AddToDesktop` - this puts a shortcut on your desktop to Flashpoint.
+
+These parameters can be passed to the installer with the use of `--params`.
+For example: `--params "/AddToDesktop"`.
+
+To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
+
 ## Notes
 
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).

--- a/automatic/flashpoint-launcher/tools/chocolateyBeforeModify.ps1
+++ b/automatic/flashpoint-launcher/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,8 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$desktopPath  = [Environment]::GetFolderPath("Desktop")
+$shortcutPath = Join-Path $desktopPath 'Flashpoint Launcher.lnk'
+
+if (Test-Path $shortcutPath) {
+  Remove-Item -Path $shortcutPath -Force | Out-Null
+}

--- a/automatic/flashpoint-launcher/tools/chocolateyUninstall.ps1
+++ b/automatic/flashpoint-launcher/tools/chocolateyUninstall.ps1
@@ -4,7 +4,7 @@ Uninstall-BinFile -Name 'Flashpoint' -Path 'Flashpoint.cmd'
 
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  ZipFileName = 'Flashpoint Core 9.7z'
+  ZipFileName = (Get-ChildItem -path $env:ChocolateyPackageFolder -include 'F*.7z.txt' -name).TrimEnd('.txt')
 }
 
 UnInstall-ChocolateyZipPackage @packageArgs

--- a/automatic/flashpoint-launcher/tools/chocolateyinstall.ps1
+++ b/automatic/flashpoint-launcher/tools/chocolateyinstall.ps1
@@ -1,24 +1,67 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
+$toolsDir   = (Split-Path -parent $MyInvocation.MyCommand.Definition)
+$installDir = Join-Path (Get-ToolsLocation) $env:ChocolateyPackageName
 
 if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
-  $archive = Join-Path $toolsDir 'Flashpoint-9.1.0_win-ia32.7z'
+  $fileName = 'Flashpoint-9.1.0_win-ia32.7z'
 } else {
-  $archive = Join-Path $toolsDir 'Flashpoint-9.1.0_win-x64.7z'
+  $fileName = 'Flashpoint-9.1.0_win-x64.7z'
 }
+
+$archive = Join-Path $toolsDir $fileName
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName
   FileFullPath = $archive
-  Destination  = $toolsDir
+  Destination  = $installDir
 }
 
 Get-ChocolateyUnzip @unzipArgs
 
+$files = Get-ChildItem $installDir -include *.exe -recurse
+
+foreach ($file in $files) {
+  New-Item "$file.ignore" -type file -force | Out-Null
+  if ($file.Name -eq 'Flashpoint.exe') {
+    $executable = $file
+  }
+}
+
+# generate a launcher command for the application binary.  The application is not well-behaved and
+# will not run correctly if it is not launched with the working directory being the same as that
+# containing the application binaries.  This secondary launcher is a way to support that while
+# working around a chocolatey shimgen feature - a command line parameter --shimgen-use-targetworkingdirectory
+# would be required on every launch without this work around as opposed to being able to simply
+# launch via the shim flashpoint.exe
+
+$applicationBinary = $executable.FullName
+$workingDirectory  = $executable.FullName.TrimEnd($executable.Name)
+$launchScript      = Join-Path $toolsDir "Flashpoint.cmd"
+$launchCommand     = "@ECHO OFF$([Environment]::NewLine)cd `"$($workingDirectory)`"$([Environment]::NewLine)`"$($applicationBinary)`""
+
+Set-Content -Path $launchScript -Value $launchCommand
+
+Install-Binfile -Name 'Flashpoint' -Path $launchScript -UseStart
+
+$pp = Get-PackageParameters
+
+if ($pp.AddToDesktop) {
+  $desktopPath  = [Environment]::GetFolderPath("Desktop")
+  $shortcutPath = Join-Path $desktopPath 'Flashpoint Launcher.lnk'
+
+  $shortcutArgs = @{
+    ShortcutFilePath = $shortcutPath
+    TargetPath       = $applicationBinary
+    WorkingDirectory = $workingDirectory
+  }
+
+  Install-ChocolateyShortcut @shortcutArgs
+}
+
 $files = Get-ChildItem $toolsDir -include '*.7z'
 
 foreach ($file in $files) {
-  Remove-Item $file -Type file -Force -ErrorAction Ignore | Out-Null
+  Remove-Item $file -Type file -Force -ErrorAction SilentlyContinue | Out-Null
 }
 

--- a/automatic/flashpoint-launcher/update.ps1
+++ b/automatic/flashpoint-launcher/update.ps1
@@ -5,10 +5,10 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/FlashpointProject/launcher/releases/latest"
 
-$re32 = 'F.+win-ia32\.7z'
-$re64 = 'F.+win-x64\.7z'
+$re32 = '(Flashpoint-(?=[^\s]+win-ia32)[^\s]+\.7z)'
+$re64 = '(Flashpoint-(?=[^\s]+win-x64)[^\s]+\.7z)'
 
-$reversion = '(?<Version>(\d+\.\d+\.\d))'
+$reVersion = '(?<Version>(\d+\.\d+\.\d+))'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -17,7 +17,7 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
@@ -26,9 +26,11 @@ function global:au_SearchReplace {
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "(\/v.*\/)(Keys.+msi)"       = "`${1}$($Latest.Filename32)"
-      "(Checksum:\s)(.+)"          = "`${1}$($Latest.Checksum32)"
-      "(\/v)([\d]+\.[\d]+\.[\d]+)" = "`${1}$($Latest.Version)"
+      "$($re32)"                  = "$($Latest.Filename32)"
+      '(Checksum32:\s*)(.+)'      = "`${1}$($Latest.Checksum32)"
+      "$($re64)"                  = "$($Latest.Filename64)"
+      '(Checksum64:\s*)(.+)'      = "`${1}$($Latest.Checksum64)"
+      '(\/)([\d]+\.[\d]+\.[\d]+)' = "`${1}$($Latest.Version)"
     }
   }
 }


### PR DESCRIPTION
Various updates to the Flashpoint packages to ensure portability across
all architectures and that the automatic updates.  The packages were failing
to install on architectures other than Windows 10 due to excess path
lengths - archive extraction was failing due to the overall path length
exceeding 260 characters.