### PR TITLE
(gh-253) VSCode Jupyter required version matching update

### DIFF
--- a/automatic/vscode-jupyter/update.ps1
+++ b/automatic/vscode-jupyter/update.ps1
@@ -7,11 +7,11 @@ $publisher = 'ms-toolsai'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+.*)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\README.md" = @{
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+.*)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{


### PR DESCRIPTION
Updated the regular expression matching on the version of VSCode
required by the extension.  The requirement had been set to an Insiders
edition which was no longer being matched by the regular expression
which considered digits only.

An update to the regular expression to accommodate this was needed.