### PR TITLE
(gh-254) Flashpoint Infinity update error

### DIFF
--- a/automatic/flashpoint-infinity/update.ps1
+++ b/automatic/flashpoint-infinity/update.ps1
@@ -33,7 +33,7 @@ function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
   $urlInfinity = $downloadPage.links | where-object href -match $reInfinityUrl | select-object -expand href | foreach-object { $releases + $_ }
-  $archive     = $urlInfinity.split('/') | select-object -last 1 -replace '%20',' '
+  $archive     = ($urlInfinity.split('/') | select-object -last 1) -replace '%20',' '
   $version     = $downloadPage.Content -match $reInfinityVersion | foreach-object { $Matches.Version }
 
   return @{


### PR DESCRIPTION
The automated updater is failing on extracting the archive name from the
URL. The failure is occurring due to an order of precedence in the
expression with a parameter binding before evaluation of the LHS string
evaluation.

Update the string evaluation with parentheses to ensure the expected
order of evaluation.