### PR TITLE
(gh-263) Correct uninstall handling for beekeeper studio portable package

### DIFF
--- a/automatic/beekeeper-studio.portable/tools/chocolateyuninstall.ps1
+++ b/automatic/beekeeper-studio.portable/tools/chocolateyuninstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 
-$executable = Join-Path $installDir 'Beekeeper-Studio-1.9.4-portable.exe'
+$toolsDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
+
+$executable = Join-Path $toolsDir 'Beekeeper-Studio-1.10.2-portable.exe'
 
 Uninstall-BinFile -Name 'BeekeeperStudio' -Path "$executable"

--- a/automatic/beekeeper-studio.portable/update.ps1
+++ b/automatic/beekeeper-studio.portable/update.ps1
@@ -28,6 +28,11 @@ function global:au_SearchReplace {
     ".\tools\chocolateyinstall.ps1" = @{
       "($rePortable)" = "$($Latest.FileName64)"
     }
+
+    ".\tools\chocolateyuninstall.ps1" = @{
+      "($rePortable)" = "$($Latest.FileName64)"
+    }
+
   }
 }
 


### PR DESCRIPTION
Uninstall was not being handled correctly as the versions for the portable
package were not included in the update scripts - the handling in the
update script had been removed to the uninstall pointed to an older
package version.