### PR TITLE
(gh-272) Default edition only if PID not supplied

### DIFF
--- a/automatic/ssrs-2019/README.md
+++ b/automatic/ssrs-2019/README.md
@@ -3,7 +3,7 @@
 [![Software license](https://img.shields.io/badge/license-proprietary-lightgrey)](https://www.microsoft.com/sql-server/sql-server-2019-pricing/)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/version-15.0.7545.4810-blue)](https://www.microsoft.com/download/details.aspx?id=100122)
+[![Software version](https://img.shields.io/badge/version-15.0.7545.20210404-blue)](https://www.microsoft.com/download/details.aspx?id=100122)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/ssrs-2019?label=Chocolatey)](https://chocolatey.org/packages/ssrs-2019)
 
 SQL Server Reporting Services (SSRS) provides a set of on-premises tools and services that create, deploy, and manage mobile and paginated reports.

--- a/automatic/ssrs-2019/ssrs-2019.nuspec
+++ b/automatic/ssrs-2019/ssrs-2019.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ssrs-2019</id>
-    <version>15.0.7545.4810</version>
+    <version>15.0.7545.4810.20210404</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/ssrs-2019</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Microsoft SQL Server 2019 Reporting Services</title>

--- a/automatic/ssrs-2019/ssrs-2019.nuspec
+++ b/automatic/ssrs-2019/ssrs-2019.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ssrs-2019</id>
-    <version>15.0.7545.4810.20210404</version>
+    <version>15.0.7545.20210404</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/ssrs-2019</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Microsoft SQL Server 2019 Reporting Services</title>

--- a/automatic/ssrs-2019/tools/chocolateybeforemodify.ps1
+++ b/automatic/ssrs-2019/tools/chocolateybeforemodify.ps1
@@ -1,1 +1,1 @@
-Get-Service SqlServerReportingServices -ErrorAction SilentlyContinue | Stop-Service
+﻿Get-Service SqlServerReportingServices -ErrorAction SilentlyContinue | Stop-Service

--- a/automatic/ssrs-2019/tools/chocolateyinstall.ps1
+++ b/automatic/ssrs-2019/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 $silentArgs = '/quiet /norestart /IAcceptLicenseTerms'
 
@@ -6,15 +6,19 @@ $silentArgs = '/quiet /norestart /IAcceptLicenseTerms'
 
 $pp = Get-PackageParameters
 
-# check the edition parameter and default to Eval if not supplied
-if ($null -eq $pp["Edition"] -or $pp["Edition"] -eq '') { $pp["Edition"] = 'Eval' }
+# edition and PID parameters are mutually exclusive so only check/default
+# the edition if no PID is provided
+if ($null -eq $pp["PID"] -or $pp["PID"] -eq '') {
+  # check the edition parameter and default to Eval if not supplied
+  if ($null -eq $pp["Edition"] -or $pp["Edition"] -eq '') {
+    $pp["Edition"] = 'Eval'
+  }
 
-if ($pp['Edition'] -notmatch $reedition) {
-  Write-Output "Unsupported edition $($pp.Edition)"
-  exit (1)
+  if ($pp['Edition'] -notmatch $reedition) {
+    Write-Output "Unsupported edition $($pp.Edition)"
+    exit (1)
+  }
 }
-
-$pp.Remove['Edition']
 
 # append remaining package arguments to the silent arguments
 $silentArgs += ($pp.GetEnumerator() | ForEach-Object { " /$($_.name)=`"$($_.value)`"" })

--- a/automatic/ssrs-2019/update.ps1
+++ b/automatic/ssrs-2019/update.ps1
@@ -9,6 +9,10 @@ $download     = "${base}confirmation.aspx?id=${productId}"
 $reversion    = '(?<Version>([\d]+\.[\d]+\.[\d]+\.[\d]+))'
 $reexecutable = 'p>(?<Executable>(.*\.exe))<'
 
+function au_BeforeUpdate {
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64Bit
+}
+
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
@@ -35,14 +39,11 @@ function global:au_GetLatest {
 
   $url = $download_page.Links | where-object { $_ -Match $filename } | Select-Object -ExpandProperty href | Select-Object -First 1
 
-  $checksum = Get-RemoteChecksum $url
-
   @{
     Version        = $version
     URL64Bit       = $url
     Filename64     = $filename
-    Checksum64     = $checksum
-    ChecksumType64 = "sha256"
+    ChecksumType64 = 'sha256'
   }
 }
 

--- a/automatic/ssrs-2019/update.ps1
+++ b/automatic/ssrs-2019/update.ps1
@@ -11,13 +11,8 @@ $reexecutable = 'p>(?<Executable>(.*\.exe))<'
 
 function global:au_SearchReplace {
   @{
-    "$($Latest.PackageName).nuspec" = @{
-      #"(>)([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(<\/)" = "`${1}$($Latest.Version)`${3}"
-      "(>)$($reversion)(<\/)" = "`${1}$($Latest.Version)`${3}"
-    }
-
     ".\README.md" = @{
-      "(-)$($reversion)(-)" = "`${1}$($Latest.Version)`${3}"
+      "$($reversion)" = "$($Latest.Version)"
     }
 
     'tools\ChocolateyInstall.ps1' = @{


### PR DESCRIPTION
The edition parameter on the install was being defaulted in all instances
which was causing an installation error if a PID was specified.  The
edition and PID parameters are mutually exclusive so the edition should
not be defaulted when a PID is supplied.