### PR TITLE
(gh-274) SQLite Shell package update issues

### DIFF
--- a/automatic/sqlite.shell/sqlite.shell.nuspec
+++ b/automatic/sqlite.shell/sqlite.shell.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>sqlite.shell</id>
     <version>3.35.2</version>
-    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/sqllite.shell</packageSourceUrl>
+    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/sqlite.shell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>SQLite Shell</title>
     <authors>D. Richard Hipp, SQLite contributors</authors>

--- a/automatic/sqlite.shell/update.ps1
+++ b/automatic/sqlite.shell/update.ps1
@@ -11,7 +11,7 @@ function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
 
   $archive = Join-Path $toolsDir $Latest.FileName32 
-  Expand-Archive -Path $archive -Destination $toolsDir
+  Expand-Archive -Path $archive -DestinationPath $toolsDir
 
   $executable = Get-ChildItem -Path $toolsDir 'sqlite?.exe' -Recurse
   $Latest.Executable = $executable.Name


### PR DESCRIPTION
An additional 'l' in the package source URL was responsible for making
the URL an invalid one.  Removed the additional 'l' in sqllite to
correct this.

The archive was not being extracted as expected due to an error in the
arguments passed to Expand-Archive.  The destination argument was not
fully specified as it was being passed as '-Destination' rather than
'-DestinationPath'.

