### PR TITLE
(gh-288) Bridge new product to file versioning

### DIFF
--- a/automatic/ssrs-2019/ssrs-2019.nuspec
+++ b/automatic/ssrs-2019/ssrs-2019.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ssrs-2019</id>
-    <version>15.0.7545.20210404</version>
+    <version>15.0.7765.17516</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/ssrs-2019</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Microsoft SQL Server 2019 Reporting Services</title>

--- a/automatic/ssrs-2019/tools/chocolateybeforemodify.ps1
+++ b/automatic/ssrs-2019/tools/chocolateybeforemodify.ps1
@@ -1,1 +1,3 @@
-﻿Get-Service SqlServerReportingServices -ErrorAction SilentlyContinue | Stop-Service
+﻿$ErrorActionPreference = 'Stop'
+
+Get-Service SqlServerReportingServices -ErrorAction SilentlyContinue | Stop-Service


### PR DESCRIPTION
Manually update the ssrs-2019 package to reflect the new product version
15.0.1102.896 which relates to the file version 15.0.7765.17516 formerly
used to sequence releases.

Updated the chocolateyBeforeModify.ps1 to include an ErrorActionPreference
directive.