### PR TITLE
(gh-297) Modify version regex for correct  capture

### DIFF
--- a/automatic/cloc/update.ps1
+++ b/automatic/cloc/update.ps1
@@ -6,7 +6,7 @@ $domain   = 'https://github.com'
 $releases = "${domain}/AlDanial/cloc/releases/latest"
 
 $refile    = '(cloc-\d.+\d+\.exe)'
-$reversion = '(-v|g\/|d\/|s-)(?<Version>([\d]+\.[\d]+))'
+$reversion = '([-\/dgs][v\/-])(?<Version>([\d]+\.[\d]+))'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix


### PR DESCRIPTION
The regular expression extracting the version needed to be updated to
correctly match the version in the download url.  There was an issue with
the regex which was not correctly matching so no version was being
extracted for use in the automatic update.