### PR TITLE
(gh-305) Include uninstall script in automatic updates

### DIFF
--- a/automatic/angband/tools/chocolateyUninstall.ps1
+++ b/automatic/angband/tools/chocolateyUninstall.ps1
@@ -2,4 +2,4 @@
 
 Uninstall-BinFile -Name 'Angband' -Path 'Angband.exe'
 
-Uninstall-ChocolateyZipPackage 'Angband' 'angband-win-4.2.1.zip'
+Uninstall-ChocolateyZipPackage 'Angband' 'angband-win-4.2.2.zip'

--- a/automatic/angband/update.ps1
+++ b/automatic/angband/update.ps1
@@ -27,6 +27,10 @@ function global:au_SearchReplace {
       "$($reFileName)" = "$($Latest.Filename32)"
     }
 
+    ".\tools\chocolateyUninstall.ps1" = @{
+      "$($reFileName)" = "$($Latest.Filename32)"
+    }
+
     ".\legal\VERIFICATION.txt" = @{
       "$($reFileName)" = "$($Latest.Filename32)"
       "$($reChecksum)" = "`${1}$($Latest.Checksum32)"


### PR DESCRIPTION
The chocolateyUninstall.ps1 file was not  included in the automatic
updates.  This resulted in a stale version being left in the uninstall
script which referred to a prior zip file on the uninstall.

The automatic update script was modified to include the uninstall
script and the version synchronized with the current package version.