### PR TITLE
(gh-309) MongoDB Shell automatic package updates failing

### DIFF
--- a/automatic/mongodb-shell/README.md
+++ b/automatic/mongodb-shell/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/mongodb-js/mongosh)](https://github.com/mongodb-js/mongosh/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/version-v0.12.1-blue)](https://github.com/mongodb-js/mongosh/releases/tag/v0.12.1)
+[![Software version](https://img.shields.io/badge/version-v0.13.0-blue)](https://github.com/mongodb-js/mongosh/releases/tag/v0.13.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/mongodb-shell?label=Chocolatey)](https://chocolatey.org/packages/mongodb-shell)
 
 The [MongoDB Shell](https://www.mongodb.com/products/shell) lets you connect to MongoDB to work with

--- a/automatic/mongodb-shell/legal/VERIFICATION.txt
+++ b/automatic/mongodb-shell/legal/VERIFICATION.txt
@@ -10,19 +10,19 @@ be verified by:
 
   https://github.com/mongodb-js/mongosh/releases
 
-and download the archive mongosh-0.12.1-win32.zip using the links in the relevant
+and download the archive mongosh-0.13.0-win32-x64.zip using the links in the relevant
 asset section of the page.
 
 Alternatively the build can be downloaded directly from
 
-  https://github.com/mongodb-js/mongosh/releases/download/v0.12.1/mongosh-0.12.1-win32.zip
+  https://github.com/mongodb-js/mongosh/releases/download/v0.12.1/mongosh-0.13.0-win32-x64.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 mongosh-0.12.1-win32.zip
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f mongosh-0.12.1-win32.zip
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 mongosh-0.13.0-win32-x64.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f mongosh-0.13.0-win32-x64.zip
 
-  File:     mongosh-0.12.1-win32.zip
+  File:     mongosh-0.13.0-win32-x64.zip
   Type:     sha256
-  Checksum: C7149358ABCBCABD443AA2AFC4804552B2CCA4D4C39CCF9A868E65E8EB4A393D
+  Checksum: 0805445A7499B0EEA16222B71F76F4186AC70F02858C410AA53B5DB35D59A3D6
 
 Contents of file LICENSE.txt is obtained from https://github.com/mongodb-js/mongosh/blob/master/LICENSE

--- a/automatic/mongodb-shell/mongodb-shell.nuspec
+++ b/automatic/mongodb-shell/mongodb-shell.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>mongodb-shell</id>
-    <version>0.12.1</version>
+    <version>0.13.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/mongodb-shell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>MongoDB Shell</title>

--- a/automatic/mongodb-shell/tools/chocolateyinstall.ps1
+++ b/automatic/mongodb-shell/tools/chocolateyinstall.ps1
@@ -6,7 +6,7 @@ if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
 
 $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
-$archive = Join-Path $toolsDir 'mongosh-0.12.1-win32.zip'
+$archive = Join-Path $toolsDir 'mongosh-0.13.0-win32-x64.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName

--- a/automatic/mongodb-shell/update.ps1
+++ b/automatic/mongodb-shell/update.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/mongodb-js/mongosh/releases/latest"
 
-$re64      = '(mongosh-.+win32\.zip)' # despite the filename the archive contains a 64-bit executable
+$re64      = '(mongosh-.+win32-x64\.zip)' # despite the filename the archive contains a 64-bit executable
 $reVersion = '(v)(?<Version>([\d]+\.[\d]+\.[\d]+))'
 
 function global:au_BeforeUpdate {
@@ -36,7 +36,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
-  
+
   $url64      = $download_page.links | where-object href -match $re64 | select-object -expand href | foreach-object { $domain + $_ }
   $filename64 = $url64 -split '/' | select-object -last 1
 


### PR DESCRIPTION
Updates were failing as the filename regex is no longer matching - with the 0.13.0 version the structure of the
filename was changed.

File naming scheme has moved from mongosh-0.12.1-win32.zip to mongosh-0.13.0-win32-x64.zip.