### PR TITLE
(gh-319) Update AddToQuickLaunch option

### DIFF
--- a/automatic/gephi/tools/chocolateyInstall.ps1
+++ b/automatic/gephi/tools/chocolateyInstall.ps1
@@ -21,7 +21,7 @@ if (-Not ($pp.count = 0)) {
         Write-Verbose("A desktop shortcut will be created for $env:ChocolateyPackageName")
         $tasks += 'desktopicon'
       }
-      'AddToQuickLauncch' {
+      'AddToQuickLaunch' {
         Write-Verbose("A shortcut on the quick launch menu will be created for $env:ChocolateyPackageName")
         $tasks += 'quicklaunchicon'
       }


### PR DESCRIPTION
The 'AddToQuickLaunch' option was not being applied if selected on
package install.  The option was not being selected due to an extra
character in the handling - AddToQuickLauncch as opposed to
AddToQuickLaunch.