### PR TITLE
(gh-181) Remove module import

### DIFF
--- a/automatic/sqljdbc/update.ps1
+++ b/automatic/sqljdbc/update.ps1
@@ -1,7 +1,6 @@
 
 Import-Module au
 
-Import-Module .\tools\chocolateyInstall.ps1
 Import-Module ..\..\scripts\chocolatey-helpers\Chocolatey-Helpers.psd1
 
 $ErrorActionPreference = 'STOP'


### PR DESCRIPTION
Removed module import.  Additional module import was causing a run
failure as it was not running in the context of the normal au calling
wrapper which was providing the function context for the
Get-PackageParameters call.