### PR TITLE
(gh-328) Update version replacement

### DIFF
--- a/automatic/sigcheck/README.md
+++ b/automatic/sigcheck/README.md
@@ -3,7 +3,7 @@
 [![Software License](https://img.shields.io/badge/License-Proprietary-grey.svg)](https://docs.microsoft.com/en-us/sysinternals/license-terms)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-2.722.80-blue)](https://docs.microsoft.com/en-us/sysinternals/downloads/sigcheck)
+[![Software version](https://img.shields.io/badge/Source-v2.80-blue)](https://docs.microsoft.com/en-us/sysinternals/downloads/sigcheck)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/sigcheck?label=Chocolatey)](https://chocolatey.org/packages/sigcheck)
 
 Sigcheck is a command-line utility that shows file version number, timestamp information, and digital signature

--- a/automatic/sigcheck/update.ps1
+++ b/automatic/sigcheck/update.ps1
@@ -3,34 +3,33 @@ import-module au
 $releases = 'https://docs.microsoft.com/en-us/sysinternals/downloads/sigcheck'
 $download = 'https://download.sysinternals.com/files/Sigcheck.zip'
 
-$reVersion = 'v(?<Version>(\d+\.\d+))'
+$reChecksum = "(?<=Checksum\s*=\s*')((?<Checksum>([^']+)))"
+$reVersion  = '(?<=v)((?<Version>([\d]+\.[\d]+)))'
 
 function global:au_BeforeUpdate {
-  if ($Latest.NuspecVersion -ne $Latest.Version) {
-    $Latest.Checksum = Get-RemoteChecksum $download
-  }
+  $Latest.Checksum = Get-RemoteChecksum $download
 }
 
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$reVersion" = "`${1}$($Latest.Version)"
+      "$reVersion" = "$($Latest.Version)"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "(checksum\s*=\s*)(.+)" = "`${1}'$($Latest.Checksum)'"
+      "$reChecksum" = "$($Latest.Checksum)"
     }
   }
 }
 
 function global:au_GetLatest {
-    $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    $version = $downloadPage.Content -match $reversion | foreach-object { $Matches.Version }
+  $version = $downloadPage.Content -match $reVersion | foreach-object { $Matches.Version }
 
-    return @{
-      Version = $version
-    }
+  return @{
+    Version = $version
+  }
 }
 
 update -ChecksumFor none -NoReadme -NoCheckUrl


### PR DESCRIPTION
The version updates were incorrectly appending a new version with the
previous one whihc broke the regular expression matching for version
replacement.  The version in the README.md needed to be reset to a valid
version and the regular expression and update matching modified.