### PR TITLE
(gh-318) Access FileName64 during package updates

### DIFF
--- a/automatic/mongodb-cli.install/update.ps1
+++ b/automatic/mongodb-cli.install/update.ps1
@@ -3,7 +3,7 @@
 $ErrorActionPreference = 'STOP'
 
 function global:au_BeforeUpdate {
-  $Lagest.FileName64 = "$($Latest.FileName64Install)"
+  $Latest.FileName64 = "$($Latest.FileName64Install)"
   $Latest.Url64      = "$($Latest.Url64Install)"
   
   Get-RemoteFiles -Purge -NoSuffix

--- a/automatic/mongodb-cli.portable/update.ps1
+++ b/automatic/mongodb-cli.portable/update.ps1
@@ -3,7 +3,7 @@
 $ErrorActionPreference = 'STOP'
 
 function global:au_BeforeUpdate {
-  $Lagest.FileName64 = "$($Latest.FileName64Portable)"
+  $Latest.FileName64 = "$($Latest.FileName64Portable)"
   $Latest.Url64      = "$($Latest.Url64Portable)"
   
   Get-RemoteFiles -Purge -NoSuffix


### PR DESCRIPTION
Package updates were failing due to the absence of FileName64 in the
latest environment when search/replace was taking place.  This was
missing due to $Latest being mis-spelled as $Lagest in the initial
assignment.