### PR TITLE
(gh-318) Match portable files in verification updates

### DIFF
--- a/automatic/mongodb-cli.portable/update.ps1
+++ b/automatic/mongodb-cli.portable/update.ps1
@@ -21,7 +21,7 @@ function global:au_SearchReplace {
 
     ".\legal\VERIFICATION.txt" = @{
       "$($reChecksum)" = "$($Latest.Checksum64)"
-      "$($reInstall)"  = "$($Latest.FileName64)"
+      "$($rePortable)" = "$($Latest.FileName64)"
       "$($reVersion)"  = "$($Latest.Version)"
     }
   }


### PR DESCRIPTION
An incorrect regular expression was being used when matching the
filenames in VERIFICATION.txt.  The expression was matching on .msi
files rather than the correct .zip.   The regular expression being used
was changed to correct this.