### PR TITLE
(gh-318) Modify install scripts on update

### DIFF
--- a/automatic/mongodb-cli.install/tools/chocolateyinstall.ps1
+++ b/automatic/mongodb-cli.install/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
-$installer = Join-Path $toolsDir 'mongocli_1.15.0_windows_x86_64.msi'
+$installer = Join-Path $toolsDir 'mongocli_1.16.0_windows_x86_64.msi'
 
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName

--- a/automatic/mongodb-cli.install/update.ps1
+++ b/automatic/mongodb-cli.install/update.ps1
@@ -24,6 +24,10 @@ function global:au_SearchReplace {
       "$($reInstall)"  = "$($Latest.FileName64)"
       "$($reVersion)"  = "$($Latest.Version)"
     }
+
+    ".\tools\chocolateyinstall.ps1" = @{
+      "$($reInstall)" = "$($Latest.FileName64)"
+    }
   }
 }
 

--- a/automatic/mongodb-cli.portable/tools/chocolateyinstall.ps1
+++ b/automatic/mongodb-cli.portable/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
-$archive = Join-Path $toolsDir 'mongocli_1.15.0_windows_x86_64.zip'
+$archive = Join-Path $toolsDir 'mongocli_1.16.0_windows_x86_64.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName

--- a/automatic/mongodb-cli.portable/update.ps1
+++ b/automatic/mongodb-cli.portable/update.ps1
@@ -24,6 +24,10 @@ function global:au_SearchReplace {
       "$($rePortable)" = "$($Latest.FileName64)"
       "$($reVersion)"  = "$($Latest.Version)"
     }
+
+    ".\tools\chocolateyinstall.ps1" = @{
+      "$($rePortable)" = "$($Latest.FileName64)"
+    }
   }
 }
 


### PR DESCRIPTION
Install scripts (chocolateyInstall.ps1) were not being picked up by the
package updates.  Modified the automatic update scripts to ensure that
the install scripts were updated with a new version of the file on
version change.