### PR TITLE
(gh-341) Update file  extensions

### DIFF
--- a/automatic/nushell.portable/legal/VERIFICATION.txt
+++ b/automatic/nushell.portable/legal/VERIFICATION.txt
@@ -10,18 +10,18 @@ be verified by:
 
   https://github.com/nushell/nushell/releases/tag/0.32.0
 
-and download the archive nu_0_32_0_windows.msi using the relevant link in the
+and download the archive nu_0_32_0_windows.zip using the relevant link in the
 assets section on the page.
 
 Alternatively the archive can be downloaded directly from
 
-  https://github.com/nushell/nushell/releases/download/0.32.0/nu_0_32_0_windows.msi
+  https://github.com/nushell/nushell/releases/download/0.32.0/nu_0_32_0_windows.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu_0_32_0_windows.msi
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu_0_32_0_windows.msi
+  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu_0_32_0_windows.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu_0_32_0_windows.zip
 
-  File:     nu_0_32_0_windows.msi
+  File:     nu_0_32_0_windows.zip
   Type:     sha256
   Checksum: C471CB4919AE15BC649C5661473EDD0BB961EAC32303A410EEEB7C18D562C070
 

--- a/automatic/nushell.portable/nushell.portable.nuspec
+++ b/automatic/nushell.portable/nushell.portable.nuspec
@@ -6,7 +6,7 @@
     <version>0.32.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nushell</packageSourceUrl>
     <owners>dgalbraith</owners>
-    <title>Nushell - A new type of shell</title>
+    <title>Nushell - A new type of shell (Portable)</title>
     <authors>Jonathan Turner, Yehuda Katz, Andrés Robalino, Nushell Contributors</authors>
     <projectUrl>https://www.nushell.sh</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@e1f9ccab58bbb3818c8b08f2ed977c0cbfae1d87/icons/nushell.png</iconUrl>
@@ -40,13 +40,13 @@ plugin system
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
+users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 * `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
+will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.

--- a/automatic/nushell.portable/tools/chocolateyInstall.ps1
+++ b/automatic/nushell.portable/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $unzipArgs = @{
   PackageName    = $env:ChocolateyPackageName
-  FileFullPath64 = Join-Path $toolsDir 'nu_0_32_0_windows.msi'
+  FileFullPath64 = Join-Path $toolsDir 'nu_0_32_0_windows.zip'
   Destination    = $toolsDir
 }
 


### PR DESCRIPTION
Package updates were failing as the regex were not matching the file
extension - .msi was being used instead of .zip.