### PR TITLE
[mssqlserver compact4.0] Fix install script failure

### DIFF
--- a/manual/mssqlserver-compact4.0/mssqlserver-compact4.0.nuspec
+++ b/manual/mssqlserver-compact4.0/mssqlserver-compact4.0.nuspec
@@ -4,7 +4,7 @@
 <metadata>
     <id>mssqlserver-compact4.0</id>
     <title>Microsoft SQLServer Compact 4.0 with SP1</title>
-    <version>4.0.8876.1</version>
+    <version>4.0.8876.100</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/manual/mssqlserver-compact4.0</packageSourceUrl>
     <authors>Microsoft</authors>
     <owners>dgalbraith</owners>

--- a/manual/mssqlserver-compact4.0/tools/chocolateyInstall.ps1
+++ b/manual/mssqlserver-compact4.0/tools/chocolateyInstall.ps1
@@ -80,7 +80,7 @@ Install-ChocolateyInstallPackage @packageArgs
 $files = Get-ChildItem $toolsDir -include *.exe -recurse
 
 foreach ($file in $files) {
-  Remove-Item "$file.ignore" -Type file -Force -ErrorAction Ignore | Out-Null
+  New-Item "$file.ignore" -Type file -Force | Out-Null
 }
 
 Remove-Item -Path $tempDir -Recurse -Force -ErrorAction Ignore | Out-Null

--- a/manual/mssqlserver-compact4.0/tools/chocolateyInstall.ps1
+++ b/manual/mssqlserver-compact4.0/tools/chocolateyInstall.ps1
@@ -80,7 +80,7 @@ Install-ChocolateyInstallPackage @packageArgs
 $files = Get-ChildItem $toolsDir -include *.exe -recurse
 
 foreach ($file in $files) {
-  Remove-Item $file.ignore -Type file -Force -ErrorAction Ignore | Out-Null
+  Remove-Item "$file.ignore" -Type file -Force -ErrorAction Ignore | Out-Null
 }
 
 Remove-Item -Path $tempDir -Recurse -Force -ErrorAction Ignore | Out-Null


### PR DESCRIPTION
I recently tried to install this package from the community repository. While the install of the underlying software succeeded, the tail end of the script bombed out with the following error:

```
ERROR: Cannot bind argument to parameter 'Path' because it is null.
```

The offending block was [here](https://github.com/dgalbraith/chocolatey-packages/blob/ffda32f8009fc24e6b7e73ef8bd3166d5741a8f5/manual/mssqlserver-compact4.0/tools/chocolateyInstall.ps1#L83):
```ps1
foreach ($file in $files) {
  Remove-Item $file.ignore -Type file -Force -ErrorAction Ignore | Out-Null
}
```

There were a few different issues with this:
- I assume the intention here was to **create** `.ignore` files for the self-extracting archive binaries that are redistributed with the package, in order to prevent shims from being generated. This would instead try to remove `.ignore` files that are neither distributed with the package nor created earlier in the install script, and failing silently.
- `$file.ignore` was being misinterpreted as an undefined property of `$file`. `-Path` should presumably be referring to a filename string instead.
- `-Type` is not recognized as a valid parameter for the `Remove-Item` cmdlet. It is, however, an alias of the `-FileType` parameter in `New-Item`.

Fixed as follows:
* Wrap `$file.ignore` in quotes to enable a correct interpretation of `-Path`.
* Change `Remove-Item` to `New-Item` to resolve the issue with `-Type`, and also implement my interpretation of the intended behavior.

I've also bumped the package's version with package fix notation. 

The install process has been successfully tested against the [Chocolatey test environment](https://github.com/chocolatey-community/chocolatey-test-environment). Assuming the binaries are available in your local repo, I believe this changeset should be packable and ready for pushing as-is.