### PR TITLE
(gh-352) Update description to ensure < 4000 characters

### DIFF
--- a/automatic/openvpn/README.md
+++ b/automatic/openvpn/README.md
@@ -9,9 +9,7 @@
 OpenVPN is a full-featured open source SSL VPN solution that accommodates a wide
 range of configurations, including remote access, site-to-site VPNs, Wi-Fi security,
 and enterprise-scale remote access solutions with load balancing, failover, and
-fine-grained access-controls. Starting with the fundamental premise that complexity
-is the enemy of security, OpenVPN offers a cost-effective, lightweight alternative
-to other VPN technologies that is well-adapted for the SME and enterprise markets.
+fine-grained access-controls.
 
 ## Features
 

--- a/automatic/openvpn/openvpn.nuspec
+++ b/automatic/openvpn/openvpn.nuspec
@@ -20,13 +20,10 @@
     <tags>openvpn vpn tunnel ssl</tags>
     <summary>A full-featured open source SSL VPN solution</summary>
     <description><![CDATA[
-
 OpenVPN is a full-featured open source SSL VPN solution that accommodates a wide
 range of configurations, including remote access, site-to-site VPNs, Wi-Fi security,
 and enterprise-scale remote access solutions with load balancing, failover, and
-fine-grained access-controls. Starting with the fundamental premise that complexity
-is the enemy of security, OpenVPN offers a cost-effective, lightweight alternative
-to other VPN technologies that is well-adapted for the SME and enterprise markets.
+fine-grained access-controls.
 
 ## Features
 


### PR DESCRIPTION
Package uploads were failing due to the length of the package
description.  As the description was greater than 4000 characters the
underlying nuget field length was being exceeded and the package upload
failing.