### PR TITLE
(gh-371) Correct package update script

### DIFF
--- a/automatic/mongodb-cli.portable/legal/VERIFICATION.txt
+++ b/automatic/mongodb-cli.portable/legal/VERIFICATION.txt
@@ -10,18 +10,18 @@ be verified by:
 
   https://github.com/mongodb/mongocli/releases/tag/v1.19.0
 
-and download the archive mongocli_1.19.0_windows_x86_64.msi using the links in the relevant
+and download the archive mongocli_1.19.0_windows_x86_64.zip using the links in the relevant
 asset section of the page.
 
 Alternatively the build can be downloaded directly from
 
-  https://github.com/mongodb/mongocli/releases/download/v1.19.0/mongocli_1.19.0_windows_x86_64.msi
+  https://github.com/mongodb/mongocli/releases/download/v1.19.0/mongocli_1.19.0_windows_x86_64.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 mongocli_1.19.0_windows_x86_64.msi
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f mongocli_1.19.0_windows_x86_64.msi
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 mongocli_1.19.0_windows_x86_64.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f mongocli_1.19.0_windows_x86_64.zip
 
-  File:     mongocli_1.19.0_windows_x86_64.msi
+  File:     mongocli_1.19.0_windows_x86_64.zip
   Type:     sha256
   Checksum: BA32AE0518C970A493E442D8325CE3D5B98D33B3F626F6032AA3F6132DA1CD5A
 

--- a/automatic/mongodb-cli.portable/tools/chocolateyinstall.ps1
+++ b/automatic/mongodb-cli.portable/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
-$archive = Join-Path $toolsDir 'mongocli_1.19.0_windows_x86_64.msi'
+$archive = Join-Path $toolsDir 'mongocli_1.19.0_windows_x86_64.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName

--- a/automatic/mongodb-cli.portable/update.ps1
+++ b/automatic/mongodb-cli.portable/update.ps1
@@ -5,7 +5,8 @@ $ErrorActionPreference = 'STOP'
 function global:au_BeforeUpdate {
   $Latest.FileName64 = "$($Latest.FileName64Portable)"
   $Latest.Url64      = "$($Latest.Url64Portable)"
-  
+  $Latest.FileType   = 'zip'
+
   Get-RemoteFiles -Purge -NoSuffix
 }
 


### PR DESCRIPTION
The package update script was not correctly handling updates due to the
portable package filename being mapped from the intended .zip file to a
.msi file.

This was occuring on file retrieval in AU due to a fallback
to a .msi file.  With no FileType being specified the downloaded file was
being saved as a .msi rather than a .zip and this was propagated
forward which resulted in an incorrect filename being used.

An explicit filetype needed to be specified in the case of the zip file.