### PR TITLE
(gh-370) Correct names used for shim generation

### DIFF
--- a/automatic/nushell.install/tools/chocolateyInstall.ps1
+++ b/automatic/nushell.install/tools/chocolateyInstall.ps1
@@ -25,7 +25,7 @@ $uninstallKey    = Get-UninstallRegistryKey -SoftwareName 'Nu'
 $installLocation = $uninstallKey.InstallLocation
 
 Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
-  Install-BinFile -Name $_.Name -Path $_.FullName
+  Install-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName
 }
 
 $pp = Get-PackageParameters

--- a/automatic/nushell.install/tools/chocolateyUninstall.ps1
+++ b/automatic/nushell.install/tools/chocolateyUninstall.ps1
@@ -4,5 +4,5 @@ $uninstallKey    = Get-UninstallRegistryKey -SoftwareName 'Nu'
 $installLocation = $uninstallKey.InstallLocation
 
 Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
-  Uninstall-BinFile -Name $_.Name -Path $_.FullName
+  Uninstall-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName
 }


### PR DESCRIPTION
Shims for the package were being installed with an additional .exe
appended.  The names used for shim generation needed updating to remove
the .exe as this is added automatically in Install-BinFile - if a file
already has the .exe extension it would be added again resulting in a
shim ending with .exe.exe.