### PR TITLE
(gh-377) Corrected automatic package updates

### DIFF
--- a/automatic/nushell.portable/legal/VERIFICATION.txt
+++ b/automatic/nushell.portable/legal/VERIFICATION.txt
@@ -10,18 +10,18 @@ be verified by:
 
   https://github.com/nushell/nushell/releases/tag/0.34.0
 
-and download the archive nu_0_34_0_windows.msi using the relevant link in the
+and download the archive nu_0_34_0_windows.zip using the relevant link in the
 assets section on the page.
 
 Alternatively the archive can be downloaded directly from
 
-  https://github.com/nushell/nushell/releases/download/0.34.0/nu_0_34_0_windows.msi
+  https://github.com/nushell/nushell/releases/download/0.34.0/nu_0_34_0_windows.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu_0_34_0_windows.msi
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu_0_34_0_windows.msi
+  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu_0_34_0_windows.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu_0_34_0_windows.zip
 
-  File:     nu_0_34_0_windows.msi
+  File:     nu_0_34_0_windows.zip
   Type:     sha256
   Checksum: 0A82B48F95C8194B9755CD537247BB83072EAB508892F9176B6A9B991AA5124C
 

--- a/automatic/nushell.portable/tools/chocolateyInstall.ps1
+++ b/automatic/nushell.portable/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $unzipArgs = @{
   PackageName    = $env:ChocolateyPackageName
-  FileFullPath64 = Join-Path $toolsDir 'nu_0_34_0_windows.msi'
+  FileFullPath64 = Join-Path $toolsDir 'nu_0_34_0_windows.zip'
   Destination    = $toolsDir
 }
 

--- a/automatic/nushell.portable/update.ps1
+++ b/automatic/nushell.portable/update.ps1
@@ -5,7 +5,8 @@ $ErrorActionPreference = 'STOP'
 function global:au_BeforeUpdate {
   $Latest.FileName64 = "$($Latest.FileName64Portable)"
   $Latest.Url64      = "$($Latest.Url64Portable)"
-  
+  $Latest.FileType   = 'zip'
+
   Get-RemoteFiles -Purge -NoSuffix
 }
 
@@ -15,7 +16,7 @@ function global:au_SearchReplace {
       "$($reVersion)"   = "$($Latest.Version)"
       "$($reCopyright)" = "$($Latest.UpdateYear)"
     }
-    
+
     ".\README.md" = @{
       "$($reVersion)" = "$($Latest.Version)"
     }


### PR DESCRIPTION
Corrected automatic pacakge updates by resetting the filenames to have
the correct extensions (.zip) and modified the update script to specify
an explicit file type (.zip) to avoid defaulting to .msi.