### PR TITLE
(gh-380) Supress URL validation on package build

### DIFF
--- a/automatic/mongodb-cli.install/update.ps1
+++ b/automatic/mongodb-cli.install/update.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'STOP'
 function global:au_BeforeUpdate {
   $Latest.FileName64 = "$($Latest.FileName64Install)"
   $Latest.Url64      = "$($Latest.Url64Install)"
-  
+
   Get-RemoteFiles -Purge -NoSuffix
 }
 
@@ -31,4 +31,4 @@ function global:au_SearchReplace {
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoCheckUrl -NoReadme

--- a/automatic/mongodb-cli.portable/update.ps1
+++ b/automatic/mongodb-cli.portable/update.ps1
@@ -32,4 +32,4 @@ function global:au_SearchReplace {
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoCheckUrl -NoReadme


### PR DESCRIPTION
The URL validation is causing an error on package build with the
package URLs being incorrectly identified as invalid.  The URLs are
actually correct so supressing the URL check for now to avoid the
issue.