### PR TITLE
(gh-388) Update filename token replacement

### DIFF
--- a/automatic/watchman/tools/chocolateyinstall.ps1
+++ b/automatic/watchman/tools/chocolateyinstall.ps1
@@ -6,7 +6,7 @@ if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
 
 $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
-$archive = Join-Path $toolsDir 'watchman-v2021.01.11.00-windows.zipwatchman-v2022.03.07.00-windows.zip'
+$archive = Join-Path $toolsDir 'watchman-v2022.03.07.00-windows.zip'
 
 $unzipArgs = @{
   PackageName = $env:ChocolateyPackageName

--- a/automatic/watchman/update.ps1
+++ b/automatic/watchman/update.ps1
@@ -29,7 +29,7 @@ function global:au_SearchReplace {
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "$($re64)" = "`${1}$($Latest.Filename64)"
+      "$($re64)" = "$($Latest.Filename64)"
     }
   }
 }
@@ -41,7 +41,7 @@ function global:au_GetLatest {
   $filename64 = $url64 -split '/' | select-object -last 1
 
   $version = $url64 -match $reVersion | foreach-object { $Matches.Version }
-  
+
   # windows binaries are not released for all versions of this package so populate $version with the current version if
   # there are no windows binaries available.  The nuspec has not been parsed at this stage so the current version is not
   # available in the environment - hardcode here and use the package update process to rewrite


### PR DESCRIPTION
Package installation was failing due to an invalid filename in the
install script.  The name was incorrect as the replacment token used for
the filename when updating the install script was incorrect - it was
leaving the existing filename in place while appending the new.

Updated the token replacement to only use the new filename when updating
the install script.