### PR TITLE
(gh-393) Reverted documentation URL to v0.35.1

### DIFF
--- a/automatic/vscode-maven/vscode-maven.nuspec
+++ b/automatic/vscode-maven/vscode-maven.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://marketplace.visualstudio.com/items/vscjava.vscode-maven/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/microsoft/vscode-maven/</projectSourceUrl>
-    <docsUrl>https://github.com/Microsoft/vscode-maven/blob/v0.35.2022031803/README.md</docsUrl>
+    <docsUrl>https://github.com/Microsoft/vscode-maven/blob/v0.35.1/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/microsoft/vscode-maven/issues</bugTrackerUrl>
     <tags>maven java vscode-maven vscode microsoft</tags>
     <summary>Maven extension for VS Code</summary>


### PR DESCRIPTION
Package validation was failing due to the DocsUrl element no longer
being resolvable.  This was due to an interim build being published for
which no tag was created.

Currently no clarity on the intended path forward - tags may have been
abandonded or it could just be an error for this build so pinning the
documentation to that for the previous (v0.35.1) published version for
now.