### PR TITLE
(gh-395) Updated domain on documentation URLs

### DIFF
--- a/automatic/mongodb-cli.install/mongodb-cli.install.nuspec
+++ b/automatic/mongodb-cli.install/mongodb-cli.install.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/mongodb/mongocli/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/mongodb/mongocli</projectSourceUrl>
-    <docsUrl>https://docs.mongodb.com/mongocli/v1.24</docsUrl>
+    <docsUrl>https://www.mongodb.com/docs/mongocli/v1.24</docsUrl>
     <bugTrackerUrl>https://github.com/mongodb/mongocli/issues</bugTrackerUrl>
     <tags>mongodb mongocli cli mongodb-atlas mongodb-cloud-manager mongodb-ops-manager</tags>
     <summary>Manage your MongoDB in the cloud</summary>
@@ -48,7 +48,7 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://docs.mongodb.com/mongocli/v1.24/release-notes</releaseNotes>
+    <releaseNotes>https://www.mongodb.com/docs/mongocli/v1.24/release-notes</releaseNotes>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/mongodb-cli.portable/mongodb-cli.portable.nuspec
+++ b/automatic/mongodb-cli.portable/mongodb-cli.portable.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/mongodb/mongocli/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/mongodb/mongocli</projectSourceUrl>
-    <docsUrl>https://docs.mongodb.com/mongocli/v1.24</docsUrl>
+    <docsUrl>https://www.mongodb.com/docs/mongocli/v1.24</docsUrl>
     <bugTrackerUrl>https://github.com/mongodb/mongocli/issues</bugTrackerUrl>
     <tags>mongodb mongocli cli mongodb-atlas mongodb-cloud-manager mongodb-ops-manager</tags>
     <summary>Manage your MongoDB in the cloud</summary>
@@ -46,7 +46,7 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://docs.mongodb.com/mongocli/v1.24/release-notes</releaseNotes>
+    <releaseNotes>https://www.mongodb.com/docs/mongocli/v1.24/release-notes</releaseNotes>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/mongodb-cli/mongodb-cli.nuspec
+++ b/automatic/mongodb-cli/mongodb-cli.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/mongodb/mongocli/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/mongodb/mongocli</projectSourceUrl>
-    <docsUrl>https://docs.mongodb.com/mongocli/v1.24</docsUrl>
+    <docsUrl>https://www.mongodb.com/docs/mongocli/v1.24</docsUrl>
     <bugTrackerUrl>https://github.com/mongodb/mongocli/issues</bugTrackerUrl>
     <tags>mongodb mongocli cli mongodb-atlas mongodb-cloud-manager mongodb-ops-manager</tags>
     <summary>Manage your MongoDB in the cloud</summary>
@@ -46,7 +46,7 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://docs.mongodb.com/mongocli/v1.24/release-notes</releaseNotes>
+    <releaseNotes>https://www.mongodb.com/docs/mongocli/v1.24/release-notes</releaseNotes>
     <dependencies>
       <dependency id="mongodb-cli.portable" version="[1.24.1]" />
     </dependencies>


### PR DESCRIPTION
The base domain for documenation URLs had been updated.  Modifed the
domain prefix on documentation references from docs.mongodb.com to
www.mongodb.com/docs to reflect this.