### PR TITLE
update kyma-cli to 2.3.0

### DIFF
--- a/automatic/kyma-cli/README.md
+++ b/automatic/kyma-cli/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/kyma-project/kyma-cli)](https://github.com/kyma-project/cli/blob/master/LICENCE/)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/version-2.0.4-blue)](https://github.com/kyma-project/cli/releases/tags/2.0.4)
+[![Software version](https://img.shields.io/badge/version-2.3.0-blue)](https://github.com/kyma-project/cli/releases/tags/2.3.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/kyma-cli?label=Chocolatey)](https://chocolatey.org/packages/kyma-cli)
 
 [Kyma CLI](https://github.com/kyma-project/cli) is a command line tool that supports [Kyma](https://kyma-project.io/) developers. It provides a set of commands you can use to install and manage [Kyma](https://kyma-project.io/).

--- a/automatic/kyma-cli/kyma-cli.nuspec
+++ b/automatic/kyma-cli/kyma-cli.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>kyma-cli</id>
-    <version>2.0.4</version>
+    <version>2.3.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/kyma-cli</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Kyma CLI - Install, Manage and Test Kyma</title>
@@ -11,10 +11,10 @@
     <projectUrl>https://kyma-project.io</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@d383fd7535734bf188270215b83a0aa2291e431e/icons/kyma-cli.png</iconUrl>
     <copyright>Kyma Project</copyright>
-    <licenseUrl>https://github.com/kyma-project/cli/blob/master/LICENCE</licenseUrl>
+    <licenseUrl>https://github.com/kyma-project/cli/blob/main/LICENCE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/kyma-project/cli</projectSourceUrl>
-    <docsUrl>https://github.com/kyma-project/cli/blob/master/README.md</docsUrl>
+    <docsUrl>https://github.com/kyma-project/cli/blob/main/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/kyma-project/cli/issues</bugTrackerUrl>
     <tags>kubernetes cli install manage test kyma</tags>
     <summary>Simple set of commands to manage a Kyma installation</summary>

--- a/automatic/kyma-cli/legal/VERIFICATION.txt
+++ b/automatic/kyma-cli/legal/VERIFICATION.txt
@@ -15,8 +15,8 @@ the links in the relevant assets section of the page.
 
 Alternatively the distributions can be downloaded directly from
 
-  https://github.com/kyma-project/cli/releases/download/2.0.4/kyma_Windows_i386.zip
-  https://github.com/kyma-project/cli/releases/download/2.0.4/kyma_Windows_x86_64.zip
+  https://github.com/kyma-project/cli/releases/download/2.3.0/kyma_Windows_i386.zip
+  https://github.com/kyma-project/cli/releases/download/2.3.0/kyma_Windows_x86_64.zip
 
 2. The installer can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash kyma_Windows_i386.zip
@@ -24,10 +24,10 @@ Alternatively the distributions can be downloaded directly from
 
   File32:         kyma_Windows_i386.zip
   ChecksumType32: sha256
-  Checksum32:     CD32342784335CFC8AC643526A361095FA692F88BC7F830F9C423352D2507464
+  Checksum32:     EC6700043125AF0CA346722C1F294DF646B655FFDDB67EF34FDEDC41C319B268
 
   File64:         kyma_Windows_x86_64.zip
   ChecksumType64: sha256
-  Checksum64:     BFB608D4D59E53E7FD7FA2BCA0D81B65F7524607677699EC49136D3482CC1574
+  Checksum64:     F05275F0C7DBD61557C6112AD65B8EDE3C8943E4680CB577667E4B6519FF4A0B
 
   Contents of file LICENSE.txt is obtained from https://github.com/kyma-project/cli/blob/master/LICENCE

--- a/automatic/kyma-cli/update.ps1
+++ b/automatic/kyma-cli/update.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/kyma-project/cli/releases/latest"
 
-$reVersion = '((?<=\\|-)(?<Version>([\d]+\.[\d]+\.[\d]+(\.[\d]+)?)))'
+$reVersion = '(?<Version>([\d]+\.[\d]+\.[\d]+(\.[\d]+)?))'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix


### PR DESCRIPTION
The kyma-cli is outdated on [choco](https://community.chocolatey.org/packages/kyma-cli) (2.0.4 instead of the 2.3.0). AU failed updating the package because the kyma version couldn't be determined:

```powershell
Invalid version:
At C:\Program Files\WindowsPowerShell\Modules\au\2021.7.18\Public\Update-Package.ps1:210 char:46
+ ... ion $Latest.Version)) { throw "Invalid version: $($Latest.Version)" }
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : OperationStopped: (Invalid version: :String) [], RuntimeException
+ FullyQualifiedErrorId : Invalid version:
```

More specifically, the [regex](https://github.com/dgalbraith/chocolatey-packages/blob/master/automatic/kyma-cli/update.ps1#L46) for extracting the kyma version from the package url failed: 

```
Given Url:  https://github.com/kyma-project/cli/releases/download/2.3.0/kyma_Windows_x86_64.zip
Regex: ((?<=\\|-)(?<Version>([\d]+\.[\d]+\.[\d]+(\.[\d]+)?)))
Result: ""
```

This PR fixes the regex and therefore should reenable the automatic update of the kyma-cli. I guess that this PR also fixes  https://github.com/dgalbraith/chocolatey-packages/issues/382
