### PR TITLE
(gh-401) Update sendtokindle version to 1.1.1.253

### DIFF
--- a/automatic/sendtokindle/sendtokindle.nuspec
+++ b/automatic/sendtokindle/sendtokindle.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>sendtokindle</id>
     <title>Send to Kindle</title>
-    <version>1.1.1.250</version>
+    <version>1.1.1.253</version>
     <authors>Amazon</authors>
     <owners>Anthony Mastrean</owners>
     <summary>Reading your personal documents on a Kindle has never been easier</summary>

--- a/automatic/sendtokindle/tools/chocolateyInstall.ps1
+++ b/automatic/sendtokindle/tools/chocolateyInstall.ps1
@@ -7,6 +7,6 @@ Install-ChocolateyPackage `
     -FileType 'EXE' `
     -Silent '/S' `
     -Url 'http://s3.amazonaws.com/sendtokindle/SendToKindleForPC-installer.exe' `
-    -Checksum '2A6F3D5F6E0477934177FE442D52861EDCE78086E3FDBBDA9FA19954C5391477' `
+    -Checksum '38A173669B3056F1C81E24145153BE2B781C2C9E44E0EAFD01E5C93D6DEEB1F0' `
     -ChecksumType 'SHA256' `
     -ValidExitCodes @(0, 1223)


### PR DESCRIPTION
Sendtokindle has been updated.  The package needs to be Updated to version 1.1.1.253 to match.

Closes gh-357
Fixes gh-401