### PR TITLE
(gh-404) Update nushell package filename handling

### DIFF
--- a/automatic/nushell.install/README.md
+++ b/automatic/nushell.install/README.md
@@ -3,7 +3,7 @@
 [![Software license](https://img.shields.io/github/license/nushell/nushell)](https://github.com/nushell/nushell/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v0.63.0-blue.svg)](https://github.com/nushell/nushell/releases/tag/0.63.0)
+[![Software version](https://img.shields.io/badge/Source-v0.64.0-blue.svg)](https://github.com/nushell/nushell/releases/tag/0.64.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/nushell.install?label=Chocolatey)](https://chocolatey.org/packages/nushell.install)
 
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your commandline. It works
@@ -25,13 +25,13 @@ plugin system
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
+users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 * `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
+will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.

--- a/automatic/nushell.install/legal/VERIFICATION.txt
+++ b/automatic/nushell.install/legal/VERIFICATION.txt
@@ -8,21 +8,21 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/nushell/nushell/releases/tag/0.63.0
+  https://github.com/nushell/nushell/releases/tag/0.64.0
 
-and download the archive nu_0_63_0_windows.msi using the relevant link in the
+and download the archive nu-0.64.0-x86_64-pc-windows-msvc.msi using the relevant link in the
 assets section on the page.
 
 Alternatively the archive can be downloaded directly from
 
-  https://github.com/nushell/nushell/releases/download/0.63.0/nu_0_63_0_windows.msi
+  https://github.com/nushell/nushell/releases/download/0.64.0/nu-0.64.0-x86_64-pc-windows-msvc.msi
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu_0_63_0_windows.msi
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu_0_63_0_windows.msi
+  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu-0.64.0-x86_64-pc-windows-msvc.msi
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu-0.64.0-x86_64-pc-windows-msvc.msi
 
-  File:     nu_0_63_0_windows.msi
+  File:     nu-0.64.0-x86_64-pc-windows-msvc.msi
   Type:     sha256
-  Checksum: 8500D99F6212AD38508AF894760E27D0EA40D4A94671FDA984C6E60F5AF93492
+  Checksum: F832419A263128E27229441CCD3B8CC5410F49F0EB91FFFCEDA3ABDB46967FCB
 
 Contents of file LICENSE.txt is obtained from https://github.com/nushell/nushell/blob/main/LICENSE

--- a/automatic/nushell.install/nushell.install.nuspec
+++ b/automatic/nushell.install/nushell.install.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nushell.install</id>
-    <version>0.63.0</version>
+    <version>0.64.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nushell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Nushell - A new type of shell</title>
@@ -40,13 +40,13 @@ plugin system
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
+users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 * `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
+will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
@@ -58,7 +58,7 @@ To have Chocolatey remember parameters on upgrade, be sure to set `choco feature
 If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://github.com/nushell/nushell/releases/tag/0.63.0</releaseNotes>
+    <releaseNotes>https://github.com/nushell/nushell/releases/tag/0.64.0</releaseNotes>
     <dependencies>
     </dependencies>
   </metadata>

--- a/automatic/nushell.install/tools/chocolateyInstall.ps1
+++ b/automatic/nushell.install/tools/chocolateyInstall.ps1
@@ -5,14 +5,14 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
   SoftwareName   = 'Nu'
-  File64         = Join-Path $toolsDir 'nu_0_63_0_windows.msi'
+  File64         = Join-Path $toolsDir 'nu-0.64.0-x86_64-pc-windows-msvc.msi'
   FileType       = 'msi'
   SilentArgs     = '/qn /norestart'
   ValidExitCodes = @(0, 3010, 1641)
 }
 
 # cache the path prior to package install so we can restore it - the installer
-# adds the bin directory form the install to the path but we will be using shims
+# adds the bin directory from the install to the path but we will be using shims
 # so this is not needed
 $path = Get-EnvironmentVariable -name 'Path' -scope 'Machine' -PreserveVariables
 

--- a/automatic/nushell.portable/README.md
+++ b/automatic/nushell.portable/README.md
@@ -3,7 +3,7 @@
 [![Software license](https://img.shields.io/github/license/nushell/nushell)](https://github.com/nushell/nushell/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v0.63.0-blue.svg)](https://github.com/nushell/nushell/releases/tag/0.63.0)
+[![Software version](https://img.shields.io/badge/Source-v0.64.0-blue.svg)](https://github.com/nushell/nushell/releases/tag/0.64.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/nushell.portable?label=Chocolatey)](https://chocolatey.org/packages/nushell.portable)
 
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your commandline. It works
@@ -25,13 +25,13 @@ plugin system
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
+users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 * `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
+will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.

--- a/automatic/nushell.portable/legal/VERIFICATION.txt
+++ b/automatic/nushell.portable/legal/VERIFICATION.txt
@@ -8,21 +8,21 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/nushell/nushell/releases/tag/0.63.0
+  https://github.com/nushell/nushell/releases/tag/0.64.0
 
-and download the archive nu_0_63_0_windows.zip using the relevant link in the
+and download the archive nu-0.64.0-x86_64-pc-windows-msvc.zip using the relevant link in the
 assets section on the page.
 
 Alternatively the archive can be downloaded directly from
 
-  https://github.com/nushell/nushell/releases/download/0.63.0/nu_0_63_0_windows.zip
+  https://github.com/nushell/nushell/releases/download/0.64.0/nu-0.64.0-x86_64-pc-windows-msvc.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu_0_63_0_windows.zip
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu_0_63_0_windows.zip
+  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 nu-0.64.0-x86_64-pc-windows-msvc.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nu-0.64.0-x86_64-pc-windows-msvc.zip
 
-  File:     nu_0_63_0_windows.zip
+  File:     nu-0.64.0-x86_64-pc-windows-msvc.zip
   Type:     sha256
-  Checksum: 8B598022CA31B919CCB10E3468D0B161DF24F983E68BD4DBBDCBD35F5207E57E
+  Checksum: 1FBB4DF9378D3F27F5EB6E75EBC3820B942F3D1EF458D29629419966559A8C9C
 
 Contents of file LICENSE.txt is obtained from https://github.com/nushell/nushell/blob/main/LICENSE

--- a/automatic/nushell.portable/nushell.portable.nuspec
+++ b/automatic/nushell.portable/nushell.portable.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nushell.portable</id>
-    <version>0.63.0</version>
+    <version>0.64.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nushell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Nushell - A new type of shell (Portable)</title>
@@ -58,7 +58,7 @@ To have Chocolatey remember parameters on upgrade, be sure to set `choco feature
 If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://github.com/nushell/nushell/releases/tag/0.63.0</releaseNotes>
+    <releaseNotes>https://github.com/nushell/nushell/releases/tag/0.64.0</releaseNotes>
     <dependencies>
     </dependencies>
   </metadata>

--- a/automatic/nushell.portable/tools/chocolateyInstall.ps1
+++ b/automatic/nushell.portable/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $unzipArgs = @{
   PackageName    = $env:ChocolateyPackageName
-  FileFullPath64 = Join-Path $toolsDir 'nu_0_63_0_windows.zip'
+  FileFullPath64 = Join-Path $toolsDir 'nu-0.64.0-x86_64-pc-windows-msvc.zip'
   Destination    = $toolsDir
 }
 

--- a/automatic/nushell/README.md
+++ b/automatic/nushell/README.md
@@ -3,7 +3,7 @@
 [![Software license](https://img.shields.io/github/license/nushell/nushell)](https://github.com/nushell/nushell/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v0.63.0-blue.svg)](https://github.com/nushell/nushell/releases/tag/0.63.0)
+[![Software version](https://img.shields.io/badge/Source-v0.64.0-blue.svg)](https://github.com/nushell/nushell/releases/tag/0.64.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/nushell?label=Chocolatey)](https://chocolatey.org/packages/nushell)
 
 Nushell, or Nu for short, is a new shell that takes a modern, structured approach to your commandline. It works
@@ -25,13 +25,13 @@ plugin system
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
+users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 * `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
+will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.

--- a/automatic/nushell/nushell.nuspec
+++ b/automatic/nushell/nushell.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nushell</id>
-    <version>0.63.0</version>
+    <version>0.64.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nushell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Nushell - A new type of shell</title>
@@ -40,13 +40,13 @@ plugin system
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Nu Shell.  By default the shortcuts will be added for all users
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
+users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 * `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
+will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
@@ -58,9 +58,9 @@ To have Chocolatey remember parameters on upgrade, be sure to set `choco feature
 If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://github.com/nushell/nushell/releases/tag/0.63.0</releaseNotes>
+    <releaseNotes>https://github.com/nushell/nushell/releases/tag/0.64.0</releaseNotes>
     <dependencies>
-      <dependency id="nushell.install" version="[0.63.0]" />
+      <dependency id="nushell.install" version="[0.64.0]" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/nushell/update.ps1
+++ b/automatic/nushell/update.ps1
@@ -6,10 +6,10 @@ $domain   = 'https://github.com'
 $releases = "${domain}/nushell/nushell/releases/latest"
 
 $reChecksum  = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
-$reCopyright = '(?<=(Copyright\s(?<CopyrightFrom>[\d]{4})-))(?<CopyrightTo>[\d]{4})'   
+$reCopyright = '(?<=(Copyright\s(?<CopyrightFrom>[\d]{4})-))(?<CopyrightTo>[\d]{4})'
 $reInstall   = "(?<=\d\/|\s|')(?<Filename>(n.+w.+msi))"
 $rePortable  = "(?<=\d\/|\s|')(?<Filename>(n.+w.+zip))"
-$reVersion   = '(?<=v|\[|\/|_)(?<Version>([\d]+\.[\d]+\.[\d](\.(?=\d)\d+)?))'
+$reVersion   = '(?<=v|\[|\/|-)(?<Version>([\d]+\.[\d]+\.[\d](\.(?=\d)\d+)?))'
 
 function global:au_BeforeUpdate {
 }
@@ -37,7 +37,7 @@ function global:au_GetLatest {
   $fileName64Portable = $url64Portable -split '/' | select-object -last 1
 
   $updateYear = (Get-Date).ToString('yyyy')
-  $version    = $fileName64Portable -replace '(?<Digits>\d+)_','${Digits}.' -match $reVersion | foreach-object { $Matches.Version }
+  $version    = $fileName64Portable -match $reVersion | foreach-object { $Matches.Version }
 
   return @{
     Url64Install       = $url64Install


### PR DESCRIPTION
The filename patterns for builds of nushell were updated from
nu_0_63_0_windows.msi to nu-0.64.0-x86_64-pc-windows-msvc.msi which broke
automatic package updates.

To address the regular expression used to match versions was updated and the
version match simplified to utilise the regex directly without any
intermediate replacement.