### PR TITLE
(gh-410) Updated to reflect build changes since 0.9.4

### DIFF
--- a/automatic/gephi/README.md
+++ b/automatic/gephi/README.md
@@ -4,7 +4,7 @@
 [![Github license](https://img.shields.io/badge/GPLv3-blue.svg)](https://github.com/gephi/gephi/blob/master/gpl-3.0.txt)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v0.9.4-blue)](https://github.com/gephi/gephi/releases/tag/v0.9.4)
+[![Software version](https://img.shields.io/badge/Source-v0.9.5-blue)](https://github.com/gephi/gephi/releases/tag/v0.9.5)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/gephi?label=Chocolatey)](https://chocolatey.org/packages/gephi)
 
 Gephi is an interactive visualization and exploration platform for all kinds of networks and complex systems, dynamic

--- a/automatic/gephi/gephi.nuspec
+++ b/automatic/gephi/gephi.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gephi</id>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/gephi</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Gephi - The Open Graph Viz Platform</title>
@@ -47,7 +47,7 @@ Platform and can be extended or reused easily through well-written APIs.
 If any package parameters are supplied no defaults will be used - only supplied parameters will be applied. The
 following package parameter can be set:
 
-* `/InstallDir`       -install Gephi to the specified folder.
+* `/InstallDir`       - install Gephi to the specified folder.
 * `/AddToDesktop`     - add a desktop shortcut
 * `/AddToQuickLaunch` - add a quick launch shortcut
 * `/AssociateGephi`   - add file association for Gephi Project files (.gephi)
@@ -63,18 +63,13 @@ To have Chocolatey remember parameters on upgrade, be sure to set `choco feature
 
 ## Notes
 
-* Requires an installation of Java 1.8+ to be available on the machine with `JDK_HOME` set to reflect the location.
-* This location will be written to `etc\gephi.conf` located under the install directory and will not be updated if
-  `JAVA_HOME` is subsequently modified
-* If `JAVA_HOME` is modified the install can be updated by editing the configuration file `etc\gephi.conf` directly
-  and updating the `jdkhome` setting to reflect or simply uninstalling and re-installing the Gephi package.
 * The installer is a combined installer containing both 32 and 64-bit versions and will always install according to the
   bitness of the OS.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://github.com/gephi/gephi/releases/tag/v0.9.4</releaseNotes>
+    <releaseNotes>https://github.com/gephi/gephi/releases/tag/v0.9.5</releaseNotes>
     <dependencies />
   </metadata>
   <files>

--- a/automatic/gephi/legal/VERIFICATION.txt
+++ b/automatic/gephi/legal/VERIFICATION.txt
@@ -8,21 +8,21 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/gephi/gephi/releases/tag/v0.9.4
+  https://github.com/gephi/gephi/releases/tag/v0.9.5
 
-and download the installer gephi-0.9.4-windows-x64.exe using the relevant links in the
-asset section of the distribution page.
+and download the installer gephi-0.9.5-windows-x64.exe using the relevant links in
+the asset section of the distribution page.
 
-Alternatively the distribution can be downloaded directly from
+Alternatively the installer can be downloaded directly from
 
-  https://github.com/gephi/gephi/releases/download/v0.9.4/gephi-0.9.4-windows-x64.exe
+  https://github.com/gephi/gephi/releases/download/v0.9.5/gephi-0.9.5-windows-x64.exe
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'gephi-0.9.4-windows-x64.exe
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f gephi-0.9.4-windows-x64.exe
+  - Use powershell function 'Get-Filehash' - Get-Filehash gephi-0.9.5-windows-x64.exe
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f gephi-0.9.5-windows-x64.exe
 
-  File:         gephi-0.9.4-windows-x64.exe
+  File:         gephi-0.9.5-windows-x64.exe
   ChecksumType: sha256
   Checksum:     6132FC3D11378A164D78E72256978B7E422D0FDD3C206C9227D9DFCD1C26B0B1
 
-  Contents of file LICENSE.txt is obtained from https://github.com/gephi/gephi/blob/master/modules/application/src/main/app-resources/COPYING.txt
+Contents of file LICENSE.txt is obtained from https://github.com/gephi/gephi/blob/master/modules/application/src/main/app-resources/COPYING.txt

--- a/automatic/gephi/tools/chocolateyInstall.ps1
+++ b/automatic/gephi/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir  = (Split-Path -parent $MyInvocation.MyCommand.Definition)
-$installer = Join-Path $toolsDir 'gephi-0.9.4-windows-x64.exe'
+$installer = Join-Path $toolsDir 'gephi-0.9.5-windows-x64.exe'
 
 $silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 

--- a/automatic/gephi/update.ps1
+++ b/automatic/gephi/update.ps1
@@ -5,9 +5,9 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/gephi/gephi/releases/latest"
 
-$reChecksum = '(Checksum:\s*)(?<Checksum>(.+))'
-$reFileName = "(?<FileName>((?<=('|\s|\d\/))g.+\.exe))"
-$reUrl      = '.+\.exe'
+$reChecksum = '(?<=(Checksum:\s{5}))(?<Checksum>(.+))'
+$reFileName = "(?<FileName>((?<=('|\s|\d\/))g.+-x64\.exe))"
+$reUrl      = '.+x64\.exe'
 $reVersion  = '(?<Version>((?<=v)\d+\.\d+\.\d+))'
 
 function global:au_BeforeUpdate {
@@ -30,7 +30,7 @@ function global:au_SearchReplace {
 
     ".\legal\VERIFICATION.txt" = @{
       "$($reFileName)" = "$($Latest.Filename)"
-      "$($reChecksum)" = "`${1}$($Latest.Checksum64)"
+      "$($reChecksum)" = "$($Latest.Checksum64)"
       "$($reVersion)"  = "$($Latest.Version)"
     }
   }
@@ -46,8 +46,9 @@ function global:au_GetLatest {
   return @{
     Url64    = $url
     FileName = $fileName
+    FileType = 'exe'
     Version  = $version
   }
 }
 
-update -ChecksumFor none -NoReadme -NoCheckUrl
+update -ChecksumFor none -NoReadme


### PR DESCRIPTION
The automatic updater for the Gephi package was failing since the 0.9.5
update due to a change of the distribution files - x32 and x64 installers
are now produced as build artifacts and the automatic update was failing
as a result.

Modified regular expressions to ensure only a single match and updated
documentation to reflect changes to the package which no longer requires
an external JDK to be available on install.