### PR TITLE
(gh-399) Fluidsynth package update

### DIFF
--- a/automatic/fluidsynth/README.md
+++ b/automatic/fluidsynth/README.md
@@ -27,5 +27,6 @@ instruments.
 
 ## Notes
 
+* Package files are extracted to the `$env:ChocolateyToolsLocation` as determined by the `Get-ToolsLocation` function
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/fluidsynth/fluidsynth.nuspec
+++ b/automatic/fluidsynth/fluidsynth.nuspec
@@ -42,6 +42,7 @@ instruments.
 
 ## Notes
 
+* Package files are extracted to the `$env:ChocolateyToolsLocation` as determined by the `Get-ToolsLocation` function
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 

--- a/automatic/fluidsynth/tools/chocolateyInstall.ps1
+++ b/automatic/fluidsynth/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
+$toolsDir  = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
 if ((Get-ProcessorBits 32) -eq 'true' -or $env:ChocolateyForceX86 -eq 'true') {
   $archive = Join-Path $toolsDir 'fluidsynth-2.2.8-winXP-x86.zip'
@@ -9,10 +9,16 @@ else {
   $archive = Join-Path $toolsDir 'fluidsynth-2.2.8-win10-x64.zip'
 }
 
+$installDir = Join-Path (Get-ToolsLocation) $env:ChocolateyPackageName
+
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName
   FileFullPath = $archive
-  Destination  = $toolsDir
+  Destination  = $installDir
 }
 
 Get-ChocolateyUnzip @unzipArgs
+
+$executable = Get-ChildItem $installDir -include fluidsynth.exe -recurse
+
+Install-Binfile -Name 'fluidsynth' -Path $executable

--- a/automatic/fluidsynth/tools/chocolateyUninstall.ps1
+++ b/automatic/fluidsynth/tools/chocolateyUninstall.ps1
@@ -1,0 +1,23 @@
+﻿$ErrorActionPreference = 'Stop'
+
+Uninstall-BinFile -Name 'fluidsynth' -Path 'fluidsynth.exe'
+
+# construct a regular expression that can be used to match the zip content file
+$reZipContent   = "{0}-{1}-*.zip.txt" -f $env:ChocolateyPackageName, $env:ChocolateyPackageVersion
+# locate the zip content file for the isntalled version in the package folder
+$zipContentFile = Get-ChildItem -Path "$env:chocolateyPackageFolder\*" -Filter $reZipContent | Select-Object -ExpandProperty FullName
+
+if ((Test-Path -path $zipContentFile)) {
+  # extract the name of original .zip file that the contents was unpacked from and use the Chocolatey helper to remove the contants
+  $zipPackage = $zipContentFile -Match '(?<ZipContentFile>^(?<Path>(?<Drive>[a-zA-Z]:)(?:\\[^:]+)?)\\(?<FileName>[^\\\n]+?)(?<Extension>\.[^.]*$|$))' | Foreach-Object { $Matches.FileName }
+  Uninstall-ChocolateyZipPackage 'fluidsynth' $zipPackage
+}
+
+$installDir = Join-Path (Get-ToolsLocation) $env:ChocolateyPackageName
+
+# remove the install directory if it is empty - if any user files have been added they will be left behind
+# noting that Uninstall-ChocolateyZipPackage will purge any files added beneath the extracted directory
+# hierarchy
+if ((Get-ChildItem -Recurse -Attributes !Directory $installDir | Measure-Object).Count -eq 0) {
+  Remove-Item $installDir -Force  -Recurse -ErrorAction SilentlyContinue | Out-Null
+}


### PR DESCRIPTION
Updates to the Fluidsynth package to:
* ensure the package does not leave residue on updates/removal
* update regular expressions to remove the use of secondary pattern group substitutions
* unzip package files into a consistent location denoted by Get-ToolsLocation