### PR TITLE
(gh-399) Remove private environment variable

### DIFF
--- a/automatic/fluidsynth/tools/chocolateyUninstall.ps1
+++ b/automatic/fluidsynth/tools/chocolateyUninstall.ps1
@@ -1,14 +1,16 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+$packageDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition | Split-Path -parent)"
+
 Uninstall-BinFile -Name 'fluidsynth' -Path 'fluidsynth.exe'
 
 # construct a regular expression that can be used to match the zip content file
 $reZipContent   = "{0}-{1}-*.zip.txt" -f $env:ChocolateyPackageName, $env:ChocolateyPackageVersion
-# locate the zip content file for the isntalled version in the package folder
-$zipContentFile = Get-ChildItem -Path "$env:chocolateyPackageFolder\*" -Filter $reZipContent | Select-Object -ExpandProperty FullName
+# locate the zip content file for the installed version in the package folder
+$zipContentFile = Get-ChildItem -Path "$packageDir\*" -Filter $reZipContent | Select-Object -ExpandProperty FullName
 
 if ((Test-Path -path $zipContentFile)) {
-  # extract the name of original .zip file that the contents was unpacked from and use the Chocolatey helper to remove the contants
+  # extract the name of original .zip file that the contents was unpacked from and use the Chocolatey helper to remove the contents
   $zipPackage = $zipContentFile -Match '(?<ZipContentFile>^(?<Path>(?<Drive>[a-zA-Z]:)(?:\\[^:]+)?)\\(?<FileName>[^\\\n]+?)(?<Extension>\.[^.]*$|$))' | Foreach-Object { $Matches.FileName }
   Uninstall-ChocolateyZipPackage 'fluidsynth' $zipPackage
 }


### PR DESCRIPTION
The package was failing validation due to the use of a private
environment variable.  Updated the uninstall script to remove the use
of $env:chocoateyPackageFolder to address this.

Rather than using the environment variable just resolved the parent
directory of the directory containing the calling script.