### PR TITLE
(gh-411) Update package documentation reference

### DIFF
--- a/automatic/vscode-maven/update.ps1
+++ b/automatic/vscode-maven/update.ps1
@@ -4,24 +4,31 @@ Import-Module ..\..\scripts\vs-marketplace\VS-Marketplace.psd1
 $extension = 'vscode-maven'
 $publisher = 'vscjava'
 
+$reChecksum      = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
+$reCopyright     = '(?<=(<copyright>)).+(?=\<)'
+$reFileName32    = '(?<=\\|\s)(?<FileName>vscjava.+\.vsix)'
+$reVersion       = '(?<=\/)(?<Version>([\d]+\.[\d]+\.[\d]+\.?[\d]*))'
+$reVSCodeVersion = '(?<=(Visual Studio Code ))(?<Version>[0-9]+\.[0-9]+\.[0-9]+\.?[\d]*)(?=( or newer))'
+
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(/v)([0-9]+\.[0-9]+\.[0-9]+)(/)"                          = "`${1}$($Latest.Version)/"
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "$($reCopyright)"     = "$($Latest.Copyright)"
+      "$($reVSCodeVersion)" = "$($Latest.VSCodeVersion)"
     }
 
     ".\README.md" = @{
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "$($reVSCodeVersion)" = "$($Latest.VSCodeVersion)"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "([0-9]+\.[0-9]+\.[0-9]+)" = "$($Latest.Version)"
+      "$($reFileName32)" = "$($Latest.FileNameBase)"
     }
 
     ".\legal\VERIFICATION.txt"      = @{
-      "([0-9]+\.[0-9]+\.[0-9]+)" = "$($Latest.Version)"
-      "(Checksum:\s*)(.*)"       = "`${1}$($Latest.Checksum32)"
+      "$($reVersion)"    = "$($Latest.Version)"
+      "$($reFileName32)" = "$($Latest.FileNameBase)"
+      "$($reChecksum)"   = "$($Latest.Checksum32)"
     }
   }
 }

--- a/automatic/vscode-maven/vscode-maven.nuspec
+++ b/automatic/vscode-maven/vscode-maven.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://marketplace.visualstudio.com/items/vscjava.vscode-maven/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/microsoft/vscode-maven/</projectSourceUrl>
-    <docsUrl>https://github.com/Microsoft/vscode-maven/blob/v0.38.2022082703/README.md</docsUrl>
+    <docsUrl>https://github.com/Microsoft/vscode-maven#readme</docsUrl>
     <bugTrackerUrl>https://github.com/microsoft/vscode-maven/issues</bugTrackerUrl>
     <tags>maven java vscode-maven vscode microsoft</tags>
     <summary>Maven extension for VS Code</summary>
@@ -40,7 +40,7 @@
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://github.com/microsoft/vscode-maven/blob/master/CHANGELOG.md</releaseNotes>
+    <releaseNotes>https://marketplace.visualstudio.com/items/vscjava.vscode-maven/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
     </dependencies>


### PR DESCRIPTION
Package validation was failing due to an invalid documentation URL - the versioning scheme for the distribtion had been updated so that it was no longer synchronized with the tagging mechanism on the Github repository.

Updated to use a standard documetnation URL that was persistent across versions and no longer associated with the Github tagged versions and refreshed the regular expression usage.