### PR TITLE
(gh-363) Correct package upgrade failures

### DIFF
--- a/automatic/nheko-reborn/tools/chocolateyUninstall.ps1
+++ b/automatic/nheko-reborn/tools/chocolateyUninstall.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName    = $env:ChocolateyPackageName
+$packageSearch  = "Nheko*"
+$installerType  = 'exe'
+$silentArgs     = '--confirm-command purge'
+$validExitCodes = @(0)
+
+$uninstallKey    = Get-UninstallRegistryKey -SoftwareName $packageSearch
+
+if ($null -ne $uninstallKey) {
+  Uninstall-ChocolateyPackage -PackageName "$($packageName)" `
+                              -FileType "$($installerType)" `
+                              -SilentArgs "$($silentArgs)" `
+                              -File "$($uninstallKey.UninstallString)" `
+                              -ValidExitCodes $validExitCodes
+}


### PR DESCRIPTION
Package upgrades were failing due to the presence of the install directory/contents which cause the new install to fail.  The directory is present as the Chocoatey auto-uninstaller is not correctly uninstalling the package - the Qt installer does not appear to be handled correctly by Chocolatey.

To address this automatic uninstall is being skipped and a specific uninstall script which correctly handles the uninstall introduced.