### PR TITLE
(gh-384) Correct automated package build

### DIFF
--- a/automatic/neck-diagrams/neck-diagrams.nuspec
+++ b/automatic/neck-diagrams/neck-diagrams.nuspec
@@ -10,7 +10,7 @@
     <authors>Digital Software Technology Ltd</authors>
     <projectUrl>https://www.neckdiagrams.com</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@aaced40197b4b4f40922fd84260d77cd7214efc9/icons/neck-diagrams.png</iconUrl>
-    <copyright>2008-2020 Digital Software Technology Ltd</copyright>
+    <copyright>Copyright 2008-2020 Digital Software Technology Ltd</copyright>
     <licenseUrl>https://www.neckdiagrams.com/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>neck-diagrams fretboard-diagram chord-chart chord-box-creator fretboard chord-box diagram trial</tags>
@@ -30,7 +30,7 @@
 
 * This package installs a trial of Neck Diagrams which is fully functional apart from:
   * can be run up to 20 times
-  * up to 8 fret boards per page
+  * up to 12 fret boards per page
   * print & export watermarks after 10 prints / exports
   * scale generator can be used up to 10 times
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).

--- a/automatic/neck-diagrams/tools/chocolateyinstall.ps1
+++ b/automatic/neck-diagrams/tools/chocolateyinstall.ps1
@@ -1,17 +1,15 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 $packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
-  fileType      = 'exe'
-  softwareName  = 'Neck Diagrams*'
-  url           = 'https://www.neckdiagrams.com/download-files/NeckDiagrams-2.2.1-Setup-32bit.exe'
-  url64bit      = 'https://www.neckdiagrams.com/download-files/NeckDiagrams-2.2.1-Setup-64bit.exe'
-  checksum      = '7be3e0b9d5701c9bf1c243c66b37aff1'
-  checksumType  = 'MD5'
-  checksum64    = 'baf8ab4edff1604ba6cb81b5b98aa335'
-  checksumType64= 'MD5'
-  silentArgs   = '/S'
-  validExitCodes= @(0)
+  packageName    = $env:ChocolateyPackageName
+  url32          = 'https://www.neckdiagrams.com/download-files/NeckDiagrams-2.2.1-Setup-32bit.exe'
+  url64          = 'https://www.neckdiagrams.com/download-files/NeckDiagrams-2.2.1-Setup-64bit.exe'
+  checksum32     = '7be3e0b9d5701c9bf1c243c66b37aff1'
+  checksumType32 = 'sha256'
+  checksum64     = 'baf8ab4edff1604ba6cb81b5b98aa335'
+  checksumType64 = 'sha256'
+  silentArgs     = '/S'
+  validExitCodes = @(0)
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/neck-diagrams/update.ps1
+++ b/automatic/neck-diagrams/update.ps1
@@ -1,64 +1,59 @@
 import-module au
 
-$ErrorActionPreference = 'STOP'
+$ErrorActionPreference = 'Stop'
 
 $releases = 'https://www.neckdiagrams.com/download'
 
+$re32         = 'h.+32bit\.exe'
+$re64         = 'h.+64bit\.exe'
+$reFileName   = 'NeckDiagrams-(?<Version>\d+(\.\d+){1,3})-Setup-([32]|[64]){2}bit\.exe'
+$reChecksum32 = "(?<=checksum32[^']*')(?<Checksum>[^']*)"
+$reChecksum64 = "(?<=checksum64[^']*')(?<Checksum>[^']*)"
+$reCopyright  = '(?<=Copyright\s+(?<CopyrightFrom>[\d]{4})-)(?<CopyrightTo>[\d]{4})'
+
+
+
+function global:au_BeforeUpdate {
+  $Latest.Checksum32 = Get-RemoteChecksum $Latest.Url32 -Algorithm 'sha256'
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.Url64 -Algorithm 'sha256'
+}
+
 function global:au_SearchReplace {
   @{
-      ".\tools\chocolateyInstall.ps1" = @{
-        "(\s*url\s*=\s*)('.*')"             = "`$1'$($Latest.URL32)'"
-        "(\s*url64bit\s*=\s*)('.*')"        = "`$1'$($Latest.URL64)'"
-        "(\s*checksum\s*=\s*)('.*')"        = "`$1'$($Latest.Checksum32)'"
-        "(\s*checksumType\s*=\s*)('.*')"    = "`$1'$($Latest.ChecksumType32)'"
-        "(\s*checksum64\s*=\s*)('.*')"      = "`$1'$($Latest.Checksum64)'"
-        "(\s*checksumType64\s*=\s*)('.*')"  = "`$1'$($Latest.ChecksumType64)'"
+    "$($Latest.PackageName).nuspec" = @{
+      "$($reCopyright)" = "$($Latest.UpdateYear)"
+    }
+
+    ".\tools\chocolateyInstall.ps1" = @{
+      "$($re32)"         = "$($Latest.Url32)"
+      "$($re64)"         = "$($Latest.Url64)"
+      "$($reChecksum32)" = "$($Latest.Checksum32)"
+      "$($reChecksum64)" = "$($Latest.Checksum64)"
     }
   }
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-  $reurl = 'NeckDiagrams-(?<Version>(\d+(\.\d+){1,3})).*-Setup-(32)|(64)bit.exe'
-  $re32  = '32bit.exe'
-  $re64  = '64bit.exe'
+  $urls = $downloadPage.links | where-object href -match $reFileName | select-object -expand href
 
-  $urls = $download_page.links | where-object href -match $reurl | select-object -expand href | foreach-object { 'https:' + $_ }
+  $url32      = $urls -match $re32 | select-object -first 1
+  $filename32 = $url32 -split '/' | Select-Object -last 1
+  $url64      = $urls -match $re64 | select-object -first 1
+  $filename64 = $url64 -split '/' | Select-Object -last 1
 
-  $url32 = $urls -match $re32 | select-object -first 1
-  $url32SegmentSize = $([System.Uri]$url32).Segments.Length
-  $filename32 = $([System.Uri]$url32).Segments[$url32SegmentSize - 1]
-
-  $url64 = $urls -match $re64 | select-object -first 1
-  $url64SegmentSize = $([System.Uri]$url64).Segments.Length
-  $filename64 = $([System.Uri]$url64).Segments[$url64SegmentSize - 1]
-
-  $version = $Matches.Version
-
-  $regex = [regex] "(?s)(\'(?<File>NeckDiagrams-(?<Version>\d+\.\d+\.\d+)-Setup-(?<Bits>(32|64)bit)\.exe\')).*?((?<Type>[a-zA-Z0-9]+)\schecksum:\s(?<Digest>[a-zA-Z0-9]*))"
-  $allmatches = $regex.Matches($download_page.Content)
-  foreach ($match in $allmatches) {
-    if ($match -match '32bit') {
-      $checksumType32=$match.Groups.Item('Type').Value
-      $checksum32=$match.Groups.Item('Digest').Value
-    } elseif ($match -match '64bit') {
-      $checksumType64=$match.Groups.Item('Type').Value
-      $checksum64=$match.Groups.Item('Digest').Value
-    }
-  }
+  $updateYear = (Get-Date).ToString('yyyy')
+  $version    = $Matches.Version
 
   return @{
-    URL32 = $url32;
-    URL64 = $url64;
-    Checksum32 = $checksum32;
-    Checksum64 = $checksum64;
-    ChecksumType32 = $checksumType32;
-    ChecksumType64 = $checksumType64;
-    Filename32 = $filename32;
-    Filename64 = $filename64;
-    Version = $version;
+    Filename32 = $filename32
+    Url32      = $url32
+    Version    = $version
+    Url64      = $url64
+    Filename64 = $filename64
+    UpdateYear = $updateYear
   }
 }
 
-update -ChecksumFor none -NoCheckUrl -NoReadme
+update -ChecksumFor none -NoReadme


### PR DESCRIPTION
The automated build of the neck-diagrams package was failing as the web page structure had changed.  Updated the package to cater for the new format and aligned the package with current approach to packages.