### PR TITLE
(gh-427) Update build image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@
 
 version: '{build}'
 max_jobs: 1
+image: Visual Studio 2022
 # History plugin requires complete log
 #clone_depth: 5
 branches:


### PR DESCRIPTION
Update the build image used for Appveyor builds to the Visual Studio 2022 version.