### PR TITLE
(gh-432) Address CVE-2022-39264

### DIFF
--- a/automatic/nheko-reborn/README.md
+++ b/automatic/nheko-reborn/README.md
@@ -3,7 +3,7 @@
 [![Software license](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/Nheko-Reborn/nheko/blob/master/COPYING)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v0.10.1-blue.svg)](https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.1)
+[![Software version](https://img.shields.io/badge/Source-v0.10.2-blue.svg)](https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.2)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/nheko-reborn?label=Chocolatey)](https://chocolatey.org/packages/nheko-reborn)
 
 The motivation behind the project is to provide a native desktop app for [Matrix](https://matrix.org/) that feels more

--- a/automatic/nheko-reborn/legal/VERIFICATION.txt
+++ b/automatic/nheko-reborn/legal/VERIFICATION.txt
@@ -8,21 +8,21 @@ be verified by:
 
 1. Go to the binary archive page
 
-  https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.1
+  https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.2
 
-and download the file nheko-v0.10.1-installer.exe using the links on the page.
+and download the file nheko-v0.10.2-installer.exe using the links on the page.
 
 Alternatively the file can be downloaded directly from
 
-  https://github.com/Nheko-Reborn/nheko/releases/download/v0.10.1/nheko-v0.10.1-installer.exe
+  https://github.com/Nheko-Reborn/nheko/releases/download/v0.10.2/nheko-v0.10.2-installer.exe
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 nheko-v0.10.1-installer.exe
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nheko-v0.10.1-installer.exe
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 nheko-v0.10.2-installer.exe
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f nheko-v0.10.2-installer.exe
 
-  File:     nheko-v0.10.1-installer.exe
+  File:     nheko-v0.10.2-installer.exe
   Type:     sha256
-  Checksum: 1C85B3867CDBB05FA99436175533633B0EACED39257F41A40A5A5C1989812209
+  Checksum: 99E75618695AD83B84ED71604CF9ADB5D434915EF5A4B37A4EB4D8E75126708E
 
 
 Contents of file LICENSE.txt is obtained from https://github.com/Nheko-Reborn/nheko/blob/master/COPYING

--- a/automatic/nheko-reborn/nheko-reborn.nuspec
+++ b/automatic/nheko-reborn/nheko-reborn.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nheko-reborn</id>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nheko-reborn</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Nheko - Native Desktop Matrix Client</title>
@@ -50,7 +50,7 @@ like a mainstream chat app ([Element](https://element.io/), Telegram etc) and le
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.1</releaseNotes>
+    <releaseNotes>https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.2</releaseNotes>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/nheko-reborn/tools/chocolateyInstall.ps1
+++ b/automatic/nheko-reborn/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  file          = "$toolsDir\nheko-v0.10.1-installer.exe"
+  file          = "$toolsDir\nheko-v0.10.2-installer.exe"
   silentArgs	= '--accept-licenses --confirm-command install'
 }
 

--- a/automatic/nheko-reborn/update.ps1
+++ b/automatic/nheko-reborn/update.ps1
@@ -36,9 +36,12 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url32      = $downloadPage.links | where-object href -match $reFileName | select-object -expand href | foreach-object { $domain + $_ }
+  $url32      = $assetsPage.links | where-object href -match $reFileName | select-object -expand href | foreach-object { $domain + $_ }
   $fileName32 = $url32 -split '/' | select-object -last 1
   $version    = $url32 -match $reVersion | foreach-object { $Matches.Version }
 


### PR DESCRIPTION
New package build pushed to address [CVE-2022-39264](https://nvd.nist.gov/vuln/detail/CVE-2022-39264).