### PR TITLE
(gh-431) Modified package updates to handle GitHub structure

### DIFF
--- a/automatic/angband/update.ps1
+++ b/automatic/angband/update.ps1
@@ -6,7 +6,7 @@ $domain   = 'https://github.com'
 $releases = "${domain}/angband/angband/releases/latest"
 
 $reFileName = "(?<FileName>(?<=\s|'|(?<=\d\/))(ang.+\.zip))"
-$reChecksum = '(Checksum:\s*)(?<Checksum>(.+))'
+$reChecksum = "(?<=Checksum:\s+)(?<Checksum>[^\s]*)"
 $reVersion  = '(?<Version>(?<=v|\/)([\d]+\.[\d]+\.[\d]+(\.*\d*)))'
 
 function global:au_BeforeUpdate {
@@ -33,16 +33,19 @@ function global:au_SearchReplace {
 
     ".\legal\VERIFICATION.txt" = @{
       "$($reFileName)" = "$($Latest.Filename32)"
-      "$($reChecksum)" = "`${1}$($Latest.Checksum32)"
+      "$($reChecksum)" = "$($Latest.Checksum32)"
       "$($reVersion)"  = "$($Latest.Version)"
     }
   }
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url32      = $downloadPage.links | where-object href -match $reFileName | select-object -expand href | foreach-object { $domain + $_ } 
+  $url32      = $assetsPage.links | where-object href -match $reFileName | select-object -expand href | foreach-object { $domain + $_ }
   $fileName32 = $Matches.FileName
 
   $version = $filename32 -split '-' | select-object -skip 1 -first 1

--- a/automatic/calibre-dedrm/legal/VERIFICATION.txt
+++ b/automatic/calibre-dedrm/legal/VERIFICATION.txt
@@ -15,7 +15,7 @@ asset section of the distribution page.
 
 Alternatively the distribution can be downloaded directly from
 
-  https://github.com/noDRM/DeDRM_tools/releases/tag/v10.0.3/DeDRM_tools_10.0.3.zip
+  https://github.com/noDRM/DeDRM_tools/releases/download/v10.0.3/DeDRM_tools_10.0.3.zip
 
 2. The archive can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash DeDRM_tools_10.0.3.zip

--- a/automatic/calibre-dedrm/update.ps1
+++ b/automatic/calibre-dedrm/update.ps1
@@ -5,8 +5,9 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/noDRM/DeDRM_tools/releases/latest"
 
-$re32      = '(DeDRM(?=[^\/])[^\/\s]+\d\.zip)'
-$reVersion = '(v)(?<Version>(\d+\.\d+\.\d+))'
+$re32       = '(DeDRM(?=[^\/])[^\/\s]+\d\.zip)'
+$reChecksum = '(?<=Checksum:\s+)(?<Checksum>[^\s]*)'
+$reVersion  = '(?<=v)(?<Version>(\d+\.\d+\.\d+))'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -23,20 +24,23 @@ function global:au_SearchReplace {
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "$($re32)"           = "$($Latest.Filename32)"
-      '(Checksum:\s*)(.+)' = "`${1}$($Latest.Checksum32)"
-      "$($reVersion)"      = "`${1}$($Latest.Version)"
+      "$($re32)"       = "$($Latest.Filename32)"
+      "$($reChecksum)" = "$($Latest.Checksum32)"
+      "$($reVersion)"  = "$($Latest.Version)"
     }
   }
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url32      = $downloadPage.links | where-object href -match $re32 | select-object -expand  href | select-object -first 1 | foreach-object { $domain + $_ }
+  $url32      = $assetsPage.links | where-object href -match $re32 | select-object -expand  href | select-object -first 1 | foreach-object { $domain + $_ }
   $fileName32 = $url32 -split '/' | select-object -last 1
 
-  $version = $downloadPage.Content -match $reversion | foreach-object { $Matches.Version }
+  $version = $assetsPage.Content -match $reVersion | foreach-object { $Matches.Version }
 
   return @{
     Url32      = $url32

--- a/automatic/cloc/update.ps1
+++ b/automatic/cloc/update.ps1
@@ -5,8 +5,9 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/AlDanial/cloc/releases/latest"
 
-$refile    = '(cloc-\d.+\d+\.exe)'
-$reversion = '([-\/dgs][v\/-])(?<Version>([\d]+\.[\d]+))'
+$reFile     = '(cloc-\d.+\d+\.exe)'
+$reChecksum = '(?<=Checksum:\s+)(?<Checksum>[^\s]*)'
+$reVersion  = '(?<=[-\/dgs][v\/-])(?<Version>([\d]+\.[\d]+))'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -15,11 +16,11 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     "$($Latest.PackageName).nuspec" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     ".\tools\chocolateyInstall.ps1" = @{
@@ -31,26 +32,27 @@ function global:au_SearchReplace {
     }
 
     ".\legal\VERIFICATION.txt"      = @{
-      "$($refile)"         = "$($Latest.FileName64)"
-      "$($reversion)"      = "`${1}$($Latest.Version)"
-      "(Checksum:\s*)(.*)" = "`${1}$($Latest.Checksum64)"
+      "$($reFile)"     = "$($Latest.FileName64)"
+      "$($reVersion)"  = "$($Latest.Version)"
+      "$($reChecksum)" = "$($Latest.Checksum64)"
     }
   }
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url            = $download_page.links | where-object href -match $refile | select-object -first 1 -expand href | foreach-object { $domain + $_ }
-  $urlSegmentSize = $([System.Uri]$url).Segments.Length
-  $filename       = $([System.Uri]$url).Segments[$urlSegmentSize - 1]
+  $url64      = $assetsPage.links | where-object href -match $reFile | select-object -first 1 -expand href | foreach-object { $domain + $_ }
+  $fileName64 = $url -split '/' | select-object -last 1
 
-  $url -match $reversion
-  $version = $Matches.Version
+  $version = $assetsPage.Content -match $reversion | foreach-object { $Matches.Version }
 
   return @{
-    FileName64 = $filename
-    Url64      = $url
+    FileName64 = $filename64
+    Url64      = $url64
     Version    = $version
   }
 }

--- a/automatic/dbgate/update.ps1
+++ b/automatic/dbgate/update.ps1
@@ -27,11 +27,15 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url64Install      = $downloadPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
+
+  $url64Install      = $assetsPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Install = $url64Install -split '/' | select-object -last 1
 
-  $url64Portable      = $downloadPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
+  $url64Portable      = $assetsPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Portable = $url64Portable -split '/' | select-object -last 1
 
   $version = $url64Portable -match $reVersion | foreach-object { $Matches.Version }
@@ -46,5 +50,5 @@ function global:au_GetLatest {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-  update -ChecksumFor none -NoReadme -NoCheckUrl
+  update -ChecksumFor none -NoReadme
 }

--- a/automatic/fluidsynth/update.ps1
+++ b/automatic/fluidsynth/update.ps1
@@ -42,14 +42,17 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url32      = $downloadPage.links | where-object href -match $reFile32 | select-object -expand href | foreach-object { $domain + $_ } | select-object -First 1
+  $url32      = $assetsPage.links | where-object href -match $reFile32 | select-object -expand href | foreach-object { $domain + $_ } | select-object -First 1
   $filename32 = $url32 -split '/' | select-object -Last 1
 
-  $url64      = $downloadPage.links | where-object href -match $reFile64 | select-object -expand href | foreach-object { $domain + $_ } | select-object -First 1
+  $url64      = $assetsPage.links | where-object href -match $reFile64 | select-object -expand href | foreach-object { $domain + $_ } | select-object -First 1
   $filename64 = $url64 -split '/' | select-object -Last 1
 
-  $version = $downloadPage.Content -match $reversion | foreach-object { $Matches.Version }
+  $version = $url64 -match $reVersion | foreach-object { $Matches.Version }
 
   return @{
     FileName32 = $filename32
@@ -60,4 +63,4 @@ function global:au_GetLatest {
   }
 }
 
-update -ChecksumFor none -NoReadme -NoCheckUrl
+update -ChecksumFor none -NoReadme

--- a/automatic/foca/update.ps1
+++ b/automatic/foca/update.ps1
@@ -36,9 +36,12 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url64      = $downloadPage.links | where-object href -match $reFileName | select-object -expand href | foreach-object { $domain + $_ }
+  $url64      = $assetsPage.links | where-object href -match $reFileName | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64 = $url64 -split '/' | select-object -last 1
   $version    = $url64 -match $reVersion | foreach-object { $Matches.Version }
 

--- a/automatic/gephi/update.ps1
+++ b/automatic/gephi/update.ps1
@@ -37,9 +37,12 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url      = $downloadPage.links | where-object href -match $reUrl | select-object -expand  href | foreach-object { $domain + $_ }
+  $url      = $assetsPage.links | where-object href -match $reUrl | select-object -expand  href | foreach-object { $domain + $_ }
   $fileName = $url -split '/' | select-object -last 1
   $version  = $fileName -split '-' | select-object -skip 1 -first 1
 

--- a/automatic/keys/legal/VERIFICATION.txt
+++ b/automatic/keys/legal/VERIFICATION.txt
@@ -10,7 +10,7 @@ be verified by:
 
   https://keys.pub
 
-and download the installer Keys-0.1.7.msi using the Download for Windows link
+and download the installer Keys-0.2.4.msi using the Download for Windows link
 in the Install section of the main page.
 
 Alternatively the distribution can be downloaded directly from
@@ -18,11 +18,11 @@ Alternatively the distribution can be downloaded directly from
   https://github.com/keys-pub/app/releases/download/v0.2.4/Keys-0.2.4.msi
 
 2. The installer can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash Keys-0.1.7.msi
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f Keys-0.1.7.msi
+  - Use powershell function 'Get-Filehash' - Get-Filehash Keys-0.2.4.msi
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f Keys-0.2.4.msi
 
+  File:     Keys-0.2.4.msi
   Type:     sha256
   Checksum: DA66C58F79787EDDF677A4A7C57A9E5C386A33A6E9482D067B5101266F2387F5
 
   Contents of file LICENSE.txt is obtained from https://github.com/keys-pub/keys/blob/master/LICENSE
-

--- a/automatic/koodo-reader/README.md
+++ b/automatic/koodo-reader/README.md
@@ -3,7 +3,7 @@
 [![Software license](https://img.shields.io/github/license/troyeguo/koodo-reader)](https://github.com/troyeguo/koodo-reader/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v1.3.3-blue.svg)](https://github.com/troyeguo/koodo-reader/releases/tag/v1.3.3)
+[![Software version](https://img.shields.io/badge/Source-v1.3.9-blue.svg)](https://github.com/troyeguo/koodo-reader/releases/tag/v1.3.9)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/koodo-reader?label=Chocolatey)](https://chocolatey.org/packages/koodo-reader)
 
 Koodo Reader is a full-featured ebook manager to help you better study and digest your books.
@@ -26,16 +26,12 @@ Koodo Reader is a full-featured ebook manager to help you better study and diges
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add desktop shortcuts for Koodoo Reader.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Koodoo Reader
 e.g. `choco install koodo-reader --package-parameters="/AddToDesktop"`
-* `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
-e.g. `choco install koodo-reader --package-parameters="/AddToStartMenu"`
-* `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
-e.g. `choco install koodo-reader --package-parameters="/AddToDesktop /User"`
-
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
+* `/NoStartMenu` - do not add a Start Menu entry for Koodoo Reader
+e.g. `choco install koodo-reader --package-parameters="/NoStartMenu"`
+* `/User` - where the user parameter is specified Koodo Reader will be installed for the current user only
+e.g. `choco install koodo-reader --package-parameters="/User"`
 
 ## Notes
 

--- a/automatic/koodo-reader/koodo-reader.nuspec
+++ b/automatic/koodo-reader/koodo-reader.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>koodo-reader</id>
-    <version>1.3.3</version>
+    <version>1.3.9</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/koodo-reader</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Koodo Reader - All-in-one eBook Reader</title>
@@ -40,16 +40,12 @@ Koodo Reader is a full-featured ebook manager to help you better study and diges
 
 The following package parameter can be set:
 
-* `/AddToDesktop` - add desktop shortcuts for Koodoo Reader.  By default the shortcuts will be added for all users  
+* `/AddToDesktop` - add a desktop shortcuts for Koodoo Reader
 e.g. `choco install koodo-reader --package-parameters="/AddToDesktop"`
-* `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
-users  
-e.g. `choco install koodo-reader --package-parameters="/AddToStartMenu"`
-* `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user  
-e.g. `choco install koodo-reader --package-parameters="/AddToDesktop /User"`
-
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
+* `/NoStartMenu` - do not add a Start Menu entry for Koodoo Reader
+e.g. `choco install koodo-reader --package-parameters="/NoStartMenu"`
+* `/User` - where the user parameter is specified Koodo Reader will be installed for the current user only
+e.g. `choco install koodo-reader --package-parameters="/User"`
 
 ## Notes
 

--- a/automatic/koodo-reader/legal/VERIFICATION.txt
+++ b/automatic/koodo-reader/legal/VERIFICATION.txt
@@ -8,21 +8,21 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/troyeguo/koodo-reader/releases/tag/v1.3.3
+  https://github.com/troyeguo/koodo-reader/releases/tag/v1.3.9
 
-and download the archive Koodo-Reader-1.3.3-Win.7z using the relevant link in the
+and download the installer Koodo-Reader-1.3.9.exe using the relevant link in the
 assets section on the page.
 
 Alternatively the archive can be downloaded directly from
 
-  https://github.com/troyeguo/koodo-reader/releases/download/v1.3.3/Koodo-Reader-1.3.3-Win.7z
+  https://github.com/troyeguo/koodo-reader/releases/download/v1.3.9/Koodo-Reader-1.3.9.exe
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 Koodo-Reader-1.3.3-Win.7z
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f Koodo-Reader-1.3.3-Win.7z
+  - Use powershell function 'Get-Filehash' - Get-Filehash -algorithm sha256 Koodo-Reader-1.3.9.exe
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f Koodo-Reader-1.3.9.exe
 
-  File:     Koodo-Reader-1.3.3-Win.7z
+  File:     Koodo-Reader-1.3.9.exe
   Type:     sha256
-  Checksum: FA178E66FA8B07DDD06E68AAAC7BE7EEC1B4A44085E2D2F63F577A492EC6AE01
+  Checksum: c49bc8ee09b582b2a792d1b505fb54d2d0ab2ee662b32c3282fce5ff89b79f14
 
 Contents of file LICENSE.txt is obtained from https://github.com/troyeguo/koodo-reader/blob/master/LICENSE

--- a/automatic/koodo-reader/tools/chocolateyUninstall.ps1
+++ b/automatic/koodo-reader/tools/chocolateyUninstall.ps1
@@ -1,0 +1,3 @@
+﻿$ErrorActionPreference = 'Stop'
+
+Uninstall-Binfile -name 'koodo-reader' -path 'Koodo Reader.exe'

--- a/automatic/mongodb-cli/update.ps1
+++ b/automatic/mongodb-cli/update.ps1
@@ -3,7 +3,7 @@
 $ErrorActionPreference = 'STOP'
 
 $domain   = 'https://github.com'
-$releases = "${domain}/mongodb/mongocli/releases/latest"
+$releases = "${domain}/mongodb/mongodb-atlas-cli/releases/latest"
 
 $reChecksum     = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
 $reInstall      = "(?<=\d\/|\s|')(?<Filename>(m.+w.+msi))"
@@ -29,11 +29,14 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/mongocli/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url64Install = $downloadPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
+  $url64Install = $assetsPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Install = $url64Install -split '/' | select-object -last 1
 
-  $url64Portable = $downloadPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
+  $url64Portable = $assetsPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Portable = $url64Portable -split '/' | select-object -last 1
 
   $version      = $url64Portable -match $reVersion | foreach-object { $Matches.Version }

--- a/automatic/naps2/update.ps1
+++ b/automatic/naps2/update.ps1
@@ -29,11 +29,14 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $urlInstall      = $downloadPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
+  $urlInstall      = $assetsPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
   $fileNameInstall = $urlInstall -split '/' | select-object -last 1
 
-  $urlPortable      = $downloadPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
+  $urlPortable      = $assetsPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
   $fileNamePortable = $urlPortable -split '/' | select-object -last 1
 
   $updateYear = (Get-Date).ToString('yyyy')

--- a/automatic/nushell/update.ps1
+++ b/automatic/nushell/update.ps1
@@ -29,11 +29,14 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
+  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
+  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $url64Install = $downloadPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
+  $url64Install = $assetsPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Install = $url64Install -split '/' | select-object -last 1
 
-  $url64Portable = $downloadPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
+  $url64Portable = $assetsPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Portable = $url64Portable -split '/' | select-object -last 1
 
   $updateYear = (Get-Date).ToString('yyyy')


### PR DESCRIPTION
All GitHub packages were broken due to a structural change on the presentation of assets associated with a tag.  With the change to the tag the AU update scripts were no longer capable of determining the version.

Modified the handling to successfully retrieve asset versions from GitHub to repair automated version checks/package updates.