### PR TITLE
(gh-431) Modified package updates to handle GitHub structure

### DIFF
--- a/automatic/pictus.install/update.ps1
+++ b/automatic/pictus.install/update.ps1
@@ -12,12 +12,12 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "$($reversion)"      = "`${1}$($Latest.Version)"
-      "(Checksum:\s*)(.+)" = "`${1}$($Latest.Checksum32)"
+      "$($reVersion)"  = "$($Latest.Version)"
+      "$($reChecksum)" = "$($Latest.Checksum32)"
     }
   }
 }

--- a/automatic/pictus.portable/update.ps1
+++ b/automatic/pictus.portable/update.ps1
@@ -7,47 +7,21 @@ function global:au_BeforeUpdate {
   $Latest.Url32  = $Latest.UrlPortable32
   $Latest.File64 = $Lstest.FileNamePortable64
   $Latest.Url64  = $Latest.UrlPortable64
+
   Get-RemoteFiles -Purge -NoSuffix
 }
 
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "`${1}$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "$($reversion)"        = "`${1}$($Latest.Version)"
-      "(Checksum32:\s*)(.+)" = "`${1}$($Latest.Checksum32)"
-      "(Checksum64:\s*)(.+)" = "`${1}$($Latest.Checksum64)"
+      "$($reVersion)"    = "$($Latest.Version)"
+      "$($reChecksum32)" = "$($Latest.Checksum32)"
+      "$($reChecksum32)" = "$($Latest.Checksum64)"
     }
-  }
-}
-
-function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
-  $urls = $downloadPage.links | where-object href -match 'Pict.{4}\.[exe|zip]' | select-object -expand href | foreach-object { $domain + $_ }
-
-  $urlInstall      = $urls -match '.*exe' | Select-Object -First 1
-  $fileNameInstall = $urlInstall -split '/' | Select-Object -Last 1
-
-  $urlPortable32      = $urls -match '.*32\.zip' | Select-Object -First 1
-  $fileNamePortable32 = $urlPortable32 -split '/' | Select-Object -Last 1
-
-  $urlPortable64      = $urls -match '.*64\.zip' | Select-Object -First 1
-  $fileNamePortable64 = $urlPortable64 -split '/' | Select-Object -Last 1
-
-  $urlInstall -match $reversion
-  $version = $matches.Version
-
-  return @{
-    UrlInstall         = $urlInstall
-    FileNameInstall    = $fileNameInstall
-    UrlPortable32      = $urlPortable32
-    FileNamePortable32 = $fileNamePortable32
-    UrlPortable64      = $urlPortable64
-    FileNamePortable64 = $fileNamePortable64
-    Version            = $version
   }
 }
 

--- a/automatic/pictus/update.ps1
+++ b/automatic/pictus/update.ps1
@@ -5,18 +5,22 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/poppeman/Pictus/releases/latest"
 
-$reversion = '(\/v|\[|-)(?<Version>([\d]+\.[\d]+\.[\d]+))'
+$reChecksum   = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
+$reChecksum32 = '(?<=Checksum32:\s*)((?<Checksum>([^\s].+)))'
+$reChecksum64 = '(?<=Checksum64:\s*)((?<Checksum>([^\s].+)))'
+$reVersion    = '(?<=\/v|\[|-)(?<Version>([\d]+\.[\d]+\.[\d]+))'
+
 function global:au_BeforeUpdate {
 }
 
 function global:au_SearchReplace {
   @{
     ".\README.md" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     "$($Latest.PackageName).nuspec" = @{
-      "$($reversion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
   }
 }
@@ -38,7 +42,7 @@ function global:au_GetLatest {
   $urlPortable64      = $urls -match '.*64\.zip' | Select-Object -First 1
   $fileNamePortable64 = $urlPortable64 -split '/' | Select-Object -Last 1
 
-  $version = $UrlInstall -Match $reversion | ForEach-Object { $Matches.Version }
+  $version = $UrlInstall -Match $reVersion | ForEach-Object { $Matches.Version }
 
   return @{
     UrlInstall         = $urlInstall


### PR DESCRIPTION
All GitHub packages were broken due to a structural change on the presentation of assets associated with a tag.  With the change to the tag the AU update scripts were no longer capable of determining the version.

Modified the handling to successfully retrieve asset versions from GitHub to repair automated version checks/package updates.