### PR TITLE
(gh-381) Package updates to reflect new URLs

### DIFF
--- a/automatic/mongodb-shell/README.md
+++ b/automatic/mongodb-shell/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/mongodb-js/mongosh)](https://github.com/mongodb-js/mongosh/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/version-v1.1.71.6.0-blue)](https://github.com/mongodb-js/mongosh/releases/tag/v1.1.71.6.0)
+[![Software version](https://img.shields.io/badge/version-v1.6.0-blue)](https://github.com/mongodb-js/mongosh/releases/tag/v1.6.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/mongodb-shell?label=Chocolatey)](https://chocolatey.org/packages/mongodb-shell)
 
 The [MongoDB Shell](https://www.mongodb.com/products/shell) lets you connect to MongoDB to work with

--- a/automatic/mongodb-shell/mongodb-shell.nuspec
+++ b/automatic/mongodb-shell/mongodb-shell.nuspec
@@ -11,10 +11,10 @@
     <projectUrl>https://www.mongodb.com/products/shell</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@8392d21c6a607d9648fb3c5d2bfe558a2ac1dd09/icons/mongodb-shell.png</iconUrl>
     <copyright>Copyright 2020 MongoDB Inc</copyright>
-    <licenseUrl>https://github.com/mongodb-js/mongosh/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/mongodb-js/mongosh/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/mongodb-js/mongosh</projectSourceUrl>
-    <docsUrl>https://docs.mongodb.com/mongodb-shell/</docsUrl>
+    <docsUrl>https://www.mongodb.com/docs/mongodb-shell</docsUrl>
     <bugTrackerUrl>https://jira.mongodb.org/projects/MONGOSH</bugTrackerUrl>
     <tags>mongodb database atlas mongodb-atlas</tags>
     <summary>The quickest way to connect to MongoDB and Atlas to work with your data and configure your database</summary>
@@ -48,7 +48,7 @@ Gives you autocomplete options based on the version of the server you are connec
 
 ]]>
     </description>
-    <releaseNotes>https://github.com/mongodb-js/mongosh/releases/tag/v1.1.71.6.0</releaseNotes>
+    <releaseNotes>https://github.com/mongodb-js/mongosh/releases/tag/v1.6.0</releaseNotes>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/mongodb-shell/update.ps1
+++ b/automatic/mongodb-shell/update.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/mongodb-js/mongosh/releases/latest"
 
-$re64       =  '(mongosh-.+win32-x64\.zip)' # despite the filename the archive contains a 64-bit executable
+$re64       = '(mongosh-.+win32-x64\.zip)' # despite the filename the archive contains a 64-bit executable
 $reChecksum = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
 $reVersion  = '(?<=v)(?<Version>([\d]+\.[\d]+\.[\d]+))'
 
@@ -16,11 +16,11 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "$($reVersion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     ".\README.md" = @{
-      "$($reVersion)" = "`${1}$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt" = @{


### PR DESCRIPTION
The mongodb shell main branch had been changed from master to main and the documentation URL had changed.

Aligned with the new GitHub branch structure and corrected the documentation URL.