### PR TITLE
(gh-441) Correct sliksvn package updates

### DIFF
--- a/automatic/sliksvn/README.md
+++ b/automatic/sliksvn/README.md
@@ -29,14 +29,12 @@ remote system, for instance a unix system with only shell access
   e.g. `choco install -y sliksvn --package-parameters="/AddToStartMenu"`
 * `/InstallDir=[directory]` - set the installation directory to `[directory]`
   e.g. `choco install -y sliksvn --package-parameters="/InstallDir=C:\Tools\sliksvn"`
-* `/NoPath` - override the default behaviour and do not add the package `bin` folder to the system `PATH`
-  e.g. `choco install -y sliksvn --package-parameters="/NoPath"`
-
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`
+* `/AddtoPath` - add the package `bin` folder to the system `PATH`
+  e.g. `choco install -y sliksvn --package-parameters="/AddToPath"`
 
 ## Notes
 
 * This package requires administrative access to install
-* Unless the package parameter `NoPath` is passed the package bin folder will be added to the system path
+* Unless the package parameter `AddToPath` is passed shims will be generated for all executables in the package
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/sliksvn/legal/VERIFICATION.txt
+++ b/automatic/sliksvn/legal/VERIFICATION.txt
@@ -9,27 +9,27 @@ be verified by:
 1. Go to the binary distribution page
 
   https://sliksvn.com/pub/
-  
-and download the installers Slik-Subversion-1.14.1-win32.msi or Slik-Subversion-1.14.1-x64.msi
+
+and download the archives Slik-Subversion-1.14.1-win32.zip or Slik-Subversion-1.14.1-x64.zip
 using the relevant links.
 
 Alternatively the installers can be downloaded directly from
 
-  https://sliksvn.com/pub/Slik-Subversion-1.14.1-win32.msi or
-  https://sliksvn.com/pub/Slik-Subversion-1.14.1-x64.msi
+  https://sliksvn.com/pub/Slik-Subversion-1.14.1-win32.zip or
+  https://sliksvn.com/pub/Slik-Subversion-1.14.1-x64.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash Slik-Subversion-1.14.1-win32.msi
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f Slik-Subversion-1.14.1-win32.msi
+  - Use powershell function 'Get-Filehash' - Get-Filehash Slik-Subversion-1.14.1-win32.zip
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f Slik-Subversion-1.14.1-win32.zip
 
-  File32:         Slik-Subversion-1.14.1-win32.msi
+  File32:         Slik-Subversion-1.14.1-win32.zip
   ChecksumType32: sha256
   Checksum32:     9BE8737D1357415ED286A1E68205F7CA932B6EE146DCFF97DB2EEFE86AD90B1D
- 
-  - Use powershell function 'Get-Filehash' - Get-Filehash Slik-Subversion-1.14.1-x64.msi
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f Slik-Subversion-1.14.1-x64.msi
 
-  File64:         Slik-Subversion-1.14.1-x64.msi
+  - Use powershell function 'Get-Filehash' - Get-Filehash Slik-Subversion-1.14.1-x64.zip
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f Slik-Subversion-1.14.1-x64.zip
+
+  File64:         Slik-Subversion-1.14.1-x64.zip
   ChecksumType64: sha256
   Checksum64:     DB82F788DDA35B5374B7383722935067AF56F7B4420956EE9A2ECE526BCA5D3D
 

--- a/automatic/sliksvn/sliksvn.nuspec
+++ b/automatic/sliksvn/sliksvn.nuspec
@@ -41,16 +41,16 @@ remote system, for instance a unix system with only shell access
 ## Package Parameters
 
 * `/AddToStartMenu` - add a Subversion documentation folder to the start menu
-  e.g. `choco install -y sliksvn --package-parameters="AddToStartMenu"`
+  e.g. `choco install -y sliksvn --package-parameters="/AddToStartMenu"`
 * `/InstallDir=[directory]` - set the installation directory to `[directory]`
-  e.g. `choco install -y sliksvn --package-parameters="InstallDir=C:\Tools"`
-* `/NoPath` - override the default behaviour and do not add the package `bin` folder to the system `PATH`
-  e.g. `choco install -y sliksvn --package-parameters="NoPath"`
-
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`
+  e.g. `choco install -y sliksvn --package-parameters="/InstallDir=C:\Tools\sliksvn"`
+* `/AddtoPath` - add the package `bin` folder to the system `PATH`
+  e.g. `choco install -y sliksvn --package-parameters="/AddToPath"`
 
 ## Notes
 
+* This package requires administrative access to install
+* Unless the package parameter `AddToPath` is passed shims will be generated for all executables in the package
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 

--- a/automatic/sliksvn/tools/chocolateyBeforeModify.ps1
+++ b/automatic/sliksvn/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,8 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$uninstallKey    = Get-UninstallRegistryKey -SoftwareName 'Slik Subversion*'
+$installLocation = $uninstallKey.InstallLocation
+
+Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
+  Uninstall-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName
+}

--- a/automatic/sliksvn/tools/chocolateyInstall.ps1
+++ b/automatic/sliksvn/tools/chocolateyInstall.ps1
@@ -1,8 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
+$toolsDir   = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
+$packageDir = $($toolsDir | Split-Path -parent)
 
-$silentArgs = "/qn /norestart /l*v `"$($env:TEMP)\$($env:ChocolateyPackageName).$($env:ChocolateyPackageVersion).MsiInstall.log`""
+$silentArgs = "/qn /norestart /l*v `"$($env:TEMP)\$($env:ChocolateyPackageName).$($env:ChocolateyPackageVersion).MsiInstall.log`" INSTALLLEVEL=300"
 
 $pp = Get-PackageParameters
 
@@ -10,6 +11,15 @@ if ($pp.InstallDir) {
   Write-Verbose("$env:ChocolateyPackageName will be installed to $($_.value)")
   $silentArgs += " INSTALLLOCATION=`"$($pp.InstallDir)`""
 }
+
+$unzipArgs = @{
+  PackageName    = $env:ChocolateyPackageName
+  FileFullPath   = Join-Path $toolsDir 'Slik-Subversion-1.14.1-win32.zip'
+  FileFullPath64 = Join-Path $toolsDir 'Slik-Subversion-1.14.1-x64.zip'
+  Destination    = $toolsDir
+}
+
+Get-ChocolateyUnzip @unzipArgs
 
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
@@ -23,23 +33,58 @@ $packageArgs = @{
 # cache the current system path prior to package install for a restore in the case where /NoPath is specified
 $path = Get-EnvironmentVariable -name 'Path' -scope 'Machine' -PreserveVariables
 
-Write-Host('SilentArgs: ' + $silentArgs)
-
 Install-ChocolateyInstallPackage @packageArgs
 
-if (!$pp.AddToStart) {
+if (-Not $pp.AddToStart) {
   # the installer adds the documentation folder automatically so remove unless it has been explicitly requested
-  Write-Host('Removing documentation folder from the start menu')
+  Write-Verbose('Removing documentation folder from the start menu')
   $subversionStart = Join-Path ([Environment]::GetFolderPath('CommonStartMenu')) 'Programs' | Join-Path -ChildPath 'Subversion'
 
   if (Test-Path $subversionStart) {
     Remove-Item -Path $subversionStart -Recurse -Force | Out-Null
   }
-} 
+}
 
-if ($pp.NoPath) {
+if (-Not $pp.AddToPath) {
   # the installer adds the bin folder of the install to the path so remove it if the path inclusion is not desired
   # removal is achieved by setting the path to the version cached immediately prior to the package install
   Write-Verbose("Restoring cached path $path")
   Install-ChocolateyEnvironmentVariable -VariableName 'PATH' -VariableValue $path -VariableType Machine
+
+  # the bin folder has not been added to the path so generate shims instead
+  if ($pp.InstallDir) {
+    $installLocation = $pp.InstallDir
+  } else {
+    if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
+      $installLocation = [Environment]::GetFolderPath('ProgramFilesX86') + [IO.Path]::DirectorySeparatorChar + 'SlikSvn'
+    } else {
+      $installLocation = [Environment]::GetFolderPath('ProgramFiles') + [IO.Path]::DirectorySeparatorChar + 'SlikSvn'
+    }
+  }
+
+  Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
+    Install-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName
+  }
+}
+
+# update the registry key to set the InstallLocation - the installer leaves this blank
+$installKey   = Get-InstallRegistryKey -SoftwareName 'Slik Subversion*'
+$registryPath = $installKey.PSPath
+
+if (Test-Path $RegistryPath) {
+  New-ItemProperty -Path $RegistryPath -Name 'InstallLocation' -Value $installLocation -PropertyType String -Force | Out-Null
+}
+
+# locate the zip content file for the installed version in the package folder
+$zipContentFile = Get-ChildItem -Path "$packageDir\*" -Filter '*.zip.txt' | Select-Object -ExpandProperty FullName
+
+if ((Test-Path -path $zipContentFile)) {
+  # extract the name of original .zip file that the contents was unpacked from and use the Chocolatey helper to remove the contents
+  $zipPackage = $zipContentFile -Match '(?<ZipContentFile>^(?<Path>(?<Drive>[a-zA-Z]:)(?:\\[^:]+)?)\\(?<FileName>[^\\\n]+?)(?<Extension>\.[^.]*$|$))' | Foreach-Object { $Matches.FileName }
+  Uninstall-ChocolateyZipPackage $env:ChocolateyPackageName $zipPackage
+}
+
+# remove the additional files added through the installation process
+foreach ($file in Get-ChildItem -Path "$packageDir\*" -Include @('*.zip.txt','*.ignore') -Recurse | Select-Object -ExpandProperty FullName) {
+  Remove-Item $file -ErrorAction SilentlyContinue -Force
 }

--- a/automatic/sliksvn/update.ps1
+++ b/automatic/sliksvn/update.ps1
@@ -4,9 +4,14 @@ $ErrorActionPreference = 'STOP'
 
 $releases = 'https://sliksvn.com/download'
 
-$re32      = '(Slik-(?=[^\s]+win32)[^\s]+\.(msi|zip))'
-$re64      = '(Slik-(?=[^\s]+-x64)[^\s]+\.(msi|zip))'
-$reVersion = '(-v*)(?<Version>([\d]+\.[\d]+\.[\d]+))'
+$re32         = '(Slik-(?=[^\s]+win32)[^\s]+\.(zip))'
+$re64         = '(Slik-(?=[^\s]+-x64)[^\s]+\.(zip))'
+$reMsi32      = '(Slik-(?=[^\s]+win32)[^\s]+\.(msi))'
+$reMsi64      = '(Slik-(?=[^\s]+-x64)[^\s]+\.(msi))'
+$reChecksum32 = '(?<=Checksum32:\s*)((?<Checksum>([^\s].+)))'
+$reChecksum64 = '(?<=Checksum64:\s*)((?<Checksum>([^\s].+)))'
+$reVersion    = '(?<=-v|-)(?<Version>([\d]+\.[\d]+\.[\d]+))'
+
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -15,41 +20,46 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     '.\README.md' = @{
-      "$reVersion" = "`${1}$($Latest.Version)"
+      "$reVersion" = "$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "$re32"                = "$($Latest.FileName32)"
-      "$re64"                = "$($Latest.FileName64)"
-      '(Checksum32:\s*)(.+)' = "`${1}$($Latest.Checksum32)"
-      '(Checksum64:\s*)(.+)' = "`${1}$($Latest.Checksum64)"
+      "$($re32)"         = "$($Latest.FileName32)"
+      "$($re64)"         = "$($Latest.FileName64)"
+      "$($reChecksum32)" = "$($Latest.Checksum32)"
+      "$($reChecksum64)" = "$($Latest.Checksum64)"
     }
 
     ".\tools\chocolateyInstall.ps1" = @{
-      "$re32" = "$($Latest.FileName32)"
-      "$re64" = "$($Latest.FileName64)"
+      "$($re32)"    = "$($Latest.FileName32)"
+      "$($re64)"    = "$($Latest.FileName64)"
+      "$($reMsi32)" = "$($Latest.MsiFileName32)"
+      "$($reMsi64)" = "$($Latest.MsiFileName64)"
     }
-
   }
 }
 
 function global:au_GetLatest {
 $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-$url32      = $downloadPage.Links | where-object href -match $re32 | select-object -expand href | foreach-object { $_.replace('zip', 'msi') }
-$fileName32 = $url32 -split '/' | select-object -last 1
+$url32         = $downloadPage.Links | where-object href -match $re32 | select-object -expand href
+$fileName32    = $url32 -split '/' | select-object -last 1
+$msiFileName32 = $fileName32.replace('zip', 'msi')
 
-$url64      = $downloadPage.Links | where-object href -match $re64 | select-object -expand href | foreach-object { $_.replace('zip', 'msi') }
-$fileName64 = $url64 -split '/' | select-object -last 1
+$url64         = $downloadPage.Links | where-object href -match $re64 | select-object -expand href
+$fileName64    = $url64 -split '/' | select-object -last 1
+$msiFileName64 = $fileName64.replace('zip', 'msi')
 
 $version = $fileName64 -match $reVersion | foreach-object { $Matches.Version }
 
   return @{
-    FileName32 = $fileName32
-    FileName64 = $fileName64
-    Url32      = $url32
-    Url64      = $url64
-    Version    = $version
+    FileName32    = $fileName32
+    FileName64    = $fileName64
+    MsiFileName32 = $msiFileName32
+    MsiFileName64 = $msiFileName64
+    Url32         = $url32
+    Url64         = $url64
+    Version       = $version
   }
 }
 


### PR DESCRIPTION
The sliksvn package was no longer updating due to a change in the resource format - the package binary distribution had changed from raw msi files to msi files additionally packaged in zip files.

Modified the updater to successfully retrieve and handle the msi files packaged in zip files and enhanced the package to utilise shims to provide a default option of not adding the install\bin directory to the path.