### PR TITLE
(gh-459) Update authme file handling

### DIFF
--- a/automatic/authme.install/legal/VERIFICATION.txt
+++ b/automatic/authme.install/legal/VERIFICATION.txt
@@ -10,18 +10,18 @@ be verified by:
 
   https://github.com/Levminer/authme/releases/tag/3.3.5
 
-and download the installer authme-3.3.5-windows-x64-installer.exe using the links in the
+and download the installer authme-3.3.5-windows-x64.msi using the links in the
 assets section of the page.
 
 Alternatively the installer can be downloaded directly from
 
-  https://github.com/Levminer/authme/releases/download/3.3.5/authme-3.3.5-windows-x64-installer.exe
+  https://github.com/Levminer/authme/releases/download/3.3.5/authme-3.3.5-windows-x64.msi
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 authme-3.3.5-windows-x64-installer.exe
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f authme-3.3.5-windows-x64-installer.exe
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 authme-3.3.5-windows-x64.msi
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f authme-3.3.5-windows-x64.msi
 
-  File:     authme-3.3.5-windows-x64-installer.exe
+  File:     authme-3.3.5-windows-x64.msi
   Type:     sha256
   Checksum: 47470657C6163EDAE5C90526431E36BC607E5848FA82792D8ED3FD6339AB2FD3
 

--- a/automatic/authme.install/tools/chocolateyInstall.ps1
+++ b/automatic/authme.install/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 
 $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
-$installer  = Join-Path $toolsDir 'authme-3.3.5-windows-x64-installer.exe'
+$installer  = Join-Path $toolsDir 'authme-3.3.5-windows-x64.msi'
 $silentArgs = '/S /AllUsers'
 
 $pp = Get-PackageParameters
@@ -14,7 +14,7 @@ if ($pp.User) {
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
   File           = $installer
-  FileType       = 'exe'
+  FileType       = 'msi'
   SilentArgs     = $silentArgs
   ValidExitCodes = @(0, 3010, 1641)
 }

--- a/automatic/authme.install/update.ps1
+++ b/automatic/authme.install/update.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'STOP'
 function global:au_BeforeUpdate {
   $Latest.FileName64 = "$($Latest.FileName64Install)"
   $Latest.Url64      = "$($Latest.Url64Install)"
-  $Latest.FileType   = 'exe'
+  $Latest.FileType   = 'msi'
 
   Get-RemoteFiles -Purge -NoSuffix
 }

--- a/automatic/authme.portable/legal/VERIFICATION.txt
+++ b/automatic/authme.portable/legal/VERIFICATION.txt
@@ -10,18 +10,18 @@ be verified by:
 
   https://github.com/Levminer/authme/releases/tag/3.3.5
 
-and download the archive authme-3.3.5-windows-x64-portable.zip using the links in the
+and download the archive authme-3.3.5-windows-x64.zip using the links in the
 assets section of the page.
 
 Alternatively the archive can be downloaded directly from
 
-  https://github.com/Levminer/authme/releases/download/3.3.5/authme-3.3.5-windows-x64-portable.zip
+  https://github.com/Levminer/authme/releases/download/3.3.5/authme-3.3.5-windows-x64.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 authme-3.3.5-windows-x64-portable.zip
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f authme-3.3.5-windows-x64-portable.zip
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 authme-3.3.5-windows-x64.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f authme-3.3.5-windows-x64.zip
 
-  File:     authme-3.3.5-windows-x64-portable.zip
+  File:     authme-3.3.5-windows-x64.zip
   Type:     sha256
   Checksum: 688A5F815C774BA174E2FC326CD160F689AD9ADA0CD59C14D1CAD6B7FEBBC3B5
 

--- a/automatic/authme.portable/tools/chocolateyInstall.ps1
+++ b/automatic/authme.portable/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
-$archive  = Join-Path $toolsDir 'authme-3.3.5-windows-x64-portable.zip'
+$archive  = Join-Path $toolsDir 'authme-3.3.5-windows-x64.zip'
 
 $pp = Get-PackageParameters
 

--- a/automatic/authme.portable/tools/chocolateyUninstall.ps1
+++ b/automatic/authme.portable/tools/chocolateyUninstall.ps1
@@ -19,7 +19,7 @@ if (Test-Path -Path $zipTargetFile) {
   $parentDirectory = Split-Path $unzipDirectory
 }
 
-Uninstall-ChocolateyZipPackage 'authme.portable' 'authme-3.3.5-*.zip'
+Uninstall-ChocolateyZipPackage 'authme.portable' 'authme-3.3.5-windows-x64.zip'
 
 # Uninstall-ChocolateyZipPackage only removes child directories unpacked from
 # the archive so remove the main and parent directories if empty


### PR DESCRIPTION
Update authme file handling to reflect the new filename structure used for release artifacts with the 4.0 updates and moved to common utility methods to locate release artifacts on GitHub.