### PR TITLE
(gh-459) Update documentation URL

### DIFF
--- a/automatic/authme.install/authme.install.nuspec
+++ b/automatic/authme.install/authme.install.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/Levminer/authme/blob/main/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Levminer/authme</projectSourceUrl>
-    <docsUrl>https://docs.authme.levminer.com/</docsUrl>
+    <docsUrl>https://github.com/Levminer/authme/blob/dev/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/Levminer/authme/issues</bugTrackerUrl>
     <tags>authenticator 2fa 2fa-client 2fa-security totp google-authenticator electron</tags>
     <summary>Simple 2FA desktop application</summary>

--- a/automatic/authme.portable/authme.portable.nuspec
+++ b/automatic/authme.portable/authme.portable.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/Levminer/authme/blob/main/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Levminer/authme</projectSourceUrl>
-    <docsUrl>https://docs.authme.levminer.com/</docsUrl>
+    <docsUrl>https://github.com/Levminer/authme/blob/dev/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/Levminer/authme/issues</bugTrackerUrl>
     <tags>authenticator 2fa 2fa-client 2fa-security totp google-authenticator electron</tags>
     <summary>Simple 2FA desktop application</summary>

--- a/automatic/authme/authme.nuspec
+++ b/automatic/authme/authme.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/Levminer/authme/blob/main/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Levminer/authme</projectSourceUrl>
-    <docsUrl>https://docs.authme.levminer.com/</docsUrl>
+    <docsUrl>https://github.com/Levminer/authme/blob/dev/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/Levminer/authme/issues</bugTrackerUrl>
     <tags>authenticator 2fa 2fa-client 2fa-security totp google-authenticator electron</tags>
     <summary>Simple 2FA desktop application</summary>


### PR DESCRIPTION
Package validation was failing due to the docsUrl element.  The location for the package documentation previously referred to no longer exists.

Updated the docsUrl element to refer to  the README.md file in the  GitHub repository.