### PR TITLE
(gh-453) Import helper scripts

### DIFF
--- a/automatic/sendtokindle/update.ps1
+++ b/automatic/sendtokindle/update.ps1
@@ -1,5 +1,5 @@
-import-module au
-Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
+Import-Module au
+Import-Module ..\..\scripts\chocolatey-helpers\Chocolatey-Helpers.psd1
 
 $ErrorActionPreference = 'STOP'
 


### PR DESCRIPTION
Package update was failing due to missing utility function.

Updated to import the helper scripts and make the ETag handling helper available in the update script.