### PR TITLE
(gh-453) Import install scripts

### DIFF
--- a/automatic/sendtokindle/update.ps1
+++ b/automatic/sendtokindle/update.ps1
@@ -1,4 +1,6 @@
 Import-Module au
+
+Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
 Import-Module ..\..\scripts\chocolatey-helpers\Chocolatey-Helpers.psd1
 
 $ErrorActionPreference = 'STOP'


### PR DESCRIPTION
Package update was failing due to missing Chocolatey install scripts.

Updated to import the Chocolatey install scripts and make the Get-WebFile function available in the update script.