### PR TITLE
(gh-473) Amended new package detection to handle x86 and x64 architectures

### DIFF
--- a/automatic/dotcover-cli/README.md
+++ b/automatic/dotcover-cli/README.md
@@ -3,16 +3,18 @@
 [![Software license](https://img.shields.io/badge/license-proprietary-lightgrey)](https://www.jetbrains.com/legal/agreements/user.html)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v2022.3-blue.svg)](https://www.jetbrains.com/dotcover/download/#section=commandline)
+[![Software version](https://img.shields.io/badge/Source-v2022.3.3-blue.svg)](https://www.jetbrains.com/dotcover/download/#section=commandline)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/dotcover-cli?label=Chocolatey)](https://chocolatey.org/packages/dotcover-cli)
 
-dotCover Command Line Tools is a free redistributable package which enables analyzing the code coverage outside of Visual Studio.
-dotCover Command Line Tools can be integrated with a Continuous Integration server.
+dotCover Command Line Tools is a free redistributable package which enables
+analysing the code coverage outside of Visual Studio.  dotCover Command Line
+Tools can be integrated with a Continuous Integration server.
 
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@7e9ae106859434f2bdde98f74517f9f3fbea1424/automatic/dotcover-cli/screenshot.png)
 
 ## Notes
 
 * Related package: [dotcover](https://chocolatey.org/packages/dotCover)
+* The 64-bit version of the pacakge supports generatinv coverage for both 32 and 64-bit applications.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/dotcover-cli/dotcover-cli.nuspec
+++ b/automatic/dotcover-cli/dotcover-cli.nuspec
@@ -3,29 +3,33 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dotcover-cli</id>
-    <version>2022.3</version>
+    <version>2022.3.3</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/dotcover-cli</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>dotCover Command Line Tools</title>
     <authors>JetBrains</authors>
-    <projectUrl>https://www.jetbrains.com/dotcover/download/#section=commandline</projectUrl>
+    <projectUrl>https://youtrack.jetbrains.com/projects/DCVR</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@7e9ae106859434f2bdde98f74517f9f3fbea1424/icons/dotcover-cli.png</iconUrl>
     <copyright>JetBrains s.r.o.</copyright>
     <licenseUrl>https://www.jetbrains.com/legal/agreements/user.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>https://www.jetbrains.com/help/dotcover/Running_Coverage_Analysis_from_the_Command_LIne.html</docsUrl>
     <mailingListUrl>https://dotnettools-support.jetbrains.com/hc/en-us/community/topics/200379915-dotCover-discussions</mailingListUrl>
-    <bugTrackerUrl>https://youtrack.jetbrains.com/oauth?state=%2Fissues%2FDCVR</bugTrackerUrl>
+    <bugTrackerUrl>https://youtrack.jetbrains.com/issues/DCVR</bugTrackerUrl>
     <tags>testing code coverage code-coverage freeware cli development jetbrains</tags>
     <summary>A standalone command line package that enables analysing code coverage outside of Visual Studio</summary>
     <description><![CDATA[
 
-dotCover Command Line Tools is a free redistributable package which enables analysing the code coverage outside of Visual Studio.  dotCover Command Line Tools can be integrated with a Continuous Integration server.
+dotCover Command Line Tools is a free redistributable package which enables
+analysing the code coverage outside of Visual Studio.  dotCover Command Line Tools
+can be integrated with a Continuous Integration server.
 
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@7e9ae106859434f2bdde98f74517f9f3fbea1424/automatic/dotcover-cli/screenshot.png)
 
 ## Notes
 
+* Related package: [dotcover](https://chocolatey.org/packages/dotCover)
+* The 64-bit version of the pacakge supports generatinv coverage for both 32 and 64-bit applications.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 

--- a/automatic/dotcover-cli/legal/VERIFICATION.txt
+++ b/automatic/dotcover-cli/legal/VERIFICATION.txt
@@ -8,21 +8,31 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://www.jetbrains.com/dotcover/download/#section=commandline
+  https://www.jetbrains.com/dotcover/download/other.html
 
-and download the archive JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.zip for Windows using the Download button on the page.
+and download the archive JetBrains.dotCover.CommandLineTools.windows-x86.2022.3.3.zip or
+JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.3.zip using the relevant links.
 
-Alternatively the archive can be downloaded directly from
+Alternatively the installer can be downloaded directly from
 
-  https://download.jetbrains.com/resharper/dotUltimate.2022.3/JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.zip
+https://download.jetbrains.com/resharper/dotUltimate.2022.3.3/JetBrains.dotCover.CommandLineTools.windows-x86.2022.3.3.zip
+https://download.jetbrains.com/resharper/dotUltimate.2022.3.3/JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.3.zip
 
-2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.zip
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.zip
-  - Download the checksums from https://download.jetbrains.com/resharper/dotUltimate.2022.3/JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.zip.sha256
+2. The archives can be validated by comparing checksums
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 JetBrains.dotCover.CommandLineTools.windows-x86.2022.3.3.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f JetBrains.dotCover.CommandLineTools.windows-x86.2022.3.3.zip
+  - Download the checksums from https://download.jetbrains.com/resharper/dotUltimate.2022.3.3/JetBrains.dotCover.CommandLineTools.windows-x86.2022.3.3.zip.sha256
 
-  File:     JetBrains.dotCover.CommandLineTools.2020.3.2.zip
-  Type:     sha256
-  Checksum: 7DE5F5748570AC7700D613CAEB532C1661C91024027DDE6678CC7F8323DFE7A7
+  File32:         JetBrains.dotCover.CommandLineTools.windows-x86.2022.3.3.zip
+  ChecksupType32: sha256
+  Checksum32:     9e86395da5615587ef25179a472d2a4075e77e3184b83244c37b918a038af770
+
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.3.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.3.zip
+  - Download the checksums from https://download.jetbrains.com/resharper/dotUltimate.2022.3.3/JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.3.zip.sha256
+
+  File64:         JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.3.zip
+  ChecksupType64: sha256
+  Checksum64:     ca16c60fe638fcaa6b0fd2911df32947f7d16eb8bec74e092bc8114ad4f2f6af
 
 Contents of file LICENSE.txt is obtained from https://www.jetbrains.com/legal/agreements/user.html

--- a/automatic/dotcover-cli/tools/chocolateyInstall.ps1
+++ b/automatic/dotcover-cli/tools/chocolateyInstall.ps1
@@ -1,7 +1,15 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
-$archive  = Join-Path $toolsDir 'JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.zip'
+$toolsDir  = Split-Path -parent $MyInvocation.MyCommand.Definition
+
+$archive32 = Join-Path $toolsDir 'JetBrains.dotCover.CommandLineTools.windows-x86.2022.3.3.zip'
+$archive64 = Join-Path $toolsDir 'JetBrains.dotCover.CommandLineTools.windows-x64.2022.3.3.zip'
+
+if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
+  $archive = $archive32
+} else {
+  $archive = $archive64
+}
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName
@@ -10,5 +18,6 @@ $unzipArgs = @{
 }
 
 Get-ChocolateyUnzip @unzipArgs
+
 Remove-Item $toolsDir\*.zip -ea 0
 Get-ChildItem $toolsDir -include *.exe -exclude 'dotCover.exe' -recurse  | Select-Object { New-Item "$_.ignore" -type file -force } | Out-Null


### PR DESCRIPTION
Package build was failing as the URL syntax was invalid - no URL was being retrieved from the JSON describing the dotCover-cli binaries.

The package and JSON were updated to include an additional package type on windows - what was  previously known as windows has been split and now there are windows32 and windows64 versions representing the x86 and x64 architectures respectively. Previously only the x64 architecture was provided and represented as windows.

Modified package update to handle this,  consolidated the regular expressions and added support for the new 32-bit binaries.