### PR TITLE
(gh-465) Install DCO driver by default

### DIFF
--- a/automatic/openvpn/README.md
+++ b/automatic/openvpn/README.md
@@ -40,17 +40,18 @@ following package parameter can be set:
 * `/GuiOnLogon`       - launch the OpenVPN GUI on user logon
 * `/Service`          - install OpenVPN service wrappers
 * `/EasyRsa`          - install EasyRSA 3 scripts for X509 certificate management
+* `/DcoDriver`        - install the OpenVPN Data Channel Offload driver
 * `/TapDriver`        - install the TAP-Windows driver (NDIS6)
 * `/WintunDriver`     - install the layer 3 TUN driver for Windows
 * `/Documentation`    - install the OpenVPN documentation
 * `/OpenSSL`          - install OpelSSL utilities for generating public/private key pairs
 * `/SampleConfig`     - install OpenVPN client/server configuration examples
 
-eg. `choco install -y openvpn --package-parameters="/InstallDir=C:\Tools\OpenVPN /AddToDesktop /Gui /GuiOnLogon /EasyRsa /TapDriver /WintunDriver /OpenSSL"`
+eg. `choco install -y openvpn --package-parameters="/InstallDir=C:\Tools\OpenVPN /AddToDesktop /Gui /GuiOnLogon /EasyRsa /DcoDriver /TapDriver /WintunDriver /OpenSSL"`
 
 An installation with no parameters specified will use the same defaults as the installer other than there will be no desktop shortcut to the OpenVPN GUI:
 
-`choco install -y openvpn --package-parameters="/Gui /GuiOnLogon /TapDriver /WintunDriver /Documentation /OpenSSL /SampleConfig"`
+`choco install -y openvpn --package-parameters="/Gui /GuiOnLogon /DcoDriver /TapDriver /WintunDriver /Documentation /OpenSSL /SampleConfig"`
 
 To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 

--- a/automatic/openvpn/openvpn.nuspec
+++ b/automatic/openvpn/openvpn.nuspec
@@ -54,13 +54,14 @@ following package parameter can be set:
 * `/GuiOnLogon`       - launch the OpenVPN GUI on user logon
 * `/Service`          - install OpenVPN service wrappers
 * `/EasyRsa`          - install EasyRSA 3 scripts for X509 certificate management
+* `/DcoDriver`        - install the OpenVPN Data Channel Offload driver
 * `/TapDriver`        - install the TAP-Windows driver (NDIS6)
 * `/WintunDriver`     - install the layer 3 TUN driver for Windows
 * `/Documentation`    - install the OpenVPN documentation
 * `/OpenSSL`          - install OpelSSL utilities for generating public/private key pairs
 * `/SampleConfig`     - install OpenVPN client/server configuration examples
 
-eg. `choco install -y openvpn --package-parameters="/InstallDir=C:\Tools\OpenVPN /AddToDesktop /Gui /GuiOnLogon /EasyRsa /TapDriver /WintunDriver /OpenSSL"`
+eg. `choco install -y openvpn --package-parameters="/InstallDir=C:\Tools\OpenVPN /AddToDesktop /Gui /GuiOnLogon /EasyRsa /DcoDriver /TapDriver /WintunDriver /OpenSSL"`
 
 An installation with no parameters specified will use the same defaults as the installer other than creating a desktop shortcut:
 

--- a/automatic/openvpn/tools/chocolateyInstall.ps1
+++ b/automatic/openvpn/tools/chocolateyInstall.ps1
@@ -33,6 +33,10 @@ if ($pp.count -gt 0) {
         Write-Verbose('EasyRSA3 X.509 certificate management scripts will be installed')
         $local += 'EasyRSA'
       }
+      'DcoDriver' {
+        Write-Verbose('The OpenVPN Data Channel Offload network driver will be installed')
+        $local += 'Drivers.OvpnDco'
+      }
       'TapDriver' {
         Write-Verbose('The TAP-Windows driver (NDIS-6) will be installed')
         $local += 'Drivers.TAPWindows6'
@@ -72,7 +76,7 @@ if ($pp.count -gt 0) {
   }
 } else {
   Write-Verbose('No parameters supplied - constructing a default parameter set')
-  $local = @('OpenVPN.GUI','OpenVPN.Documentation','OpenVPN.SampleCfg','OpenVPN','OpenVPN.GUI.OnLogon','Drivers.TAPWindows6','Drivers','Drivers.Wintun')
+  $local = @('OpenVPN.GUI','OpenVPN.Documentation','OpenVPN.SampleCfg','OpenVPN','OpenVPN.GUI.OnLogon','Drivers.OvpnDco', 'Drivers.TAPWindows6','Drivers','Drivers.Wintun')
 }
 
 $silentArgs += " ADDLOCAL=`"{0}`"" -f ($local -join ",")


### PR DESCRIPTION
This should resolve #465 

I wonder if it's time to not install any of the other drivers by default?  I really have no idea on their status.