### PR TITLE
(gh-484) Updated Winaero Tweaker Package Version 1.55

### DIFF
--- a/manual/winaero-tweaker.install/README.md
+++ b/manual/winaero-tweaker.install/README.md
@@ -3,7 +3,7 @@
 [![Software license ©Sergey Tkachenko](https://img.shields.io/badge/license-Copyright-lightgrey)](https://winaerotweaker.com/#eula)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-1.40.0.0-blue.svg)](https://winaerotweaker.com)
+[![Software version](https://img.shields.io/badge/Source-1.55.0.0-blue.svg)](https://winaerotweaker.com)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/winaero-tweaker.install?label=Chocolatey)](https://chocolatey.org/packages/winaero-tweaker.install)
 
 Winaero Tweaker is a freeware all-in-one application that comes with dozens of options for fine-grained tuning of various Windows settings and features.

--- a/manual/winaero-tweaker.install/tools/chocolateyinstall.ps1
+++ b/manual/winaero-tweaker.install/tools/chocolateyinstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
   unzipLocation = $toolsDir
   fileType      = 'zip'
   url           = 'https://winaerotweaker.com/download/winaerotweaker.zip'
-  checksum      = '137A628D2CA222BA42FCFB3696FEFE93012A13ECCD4F4408E7FFDAC33CD7D56F'
+  checksum      = '370095778b69f763af03e553f5a83b192c7183d098cb0d87350f66fb525573b8'
   checksumType  = 'sha256'
   options = @{
     headers = @{
@@ -21,7 +21,7 @@ Install-ChocolateyZipPackage @packageArgs
 $packageArgs = @{
   packageName    = $packageName
   fileType       = 'exe'
-  file           = '{0}\WinaeroTweaker-{1}-setup.exe' -f $toolsDir, $env:packageVersion
+  file           = '{0}\WinaeroTweaker-{1}.0-setup.exe' -f $toolsDir, $env:packageVersion
   silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
   validExitCodes = @(0)
 }

--- a/manual/winaero-tweaker.install/winaero-tweaker.install.nuspec
+++ b/manual/winaero-tweaker.install/winaero-tweaker.install.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>winaero-tweaker.install</id>
-    <version>1.40.0.0</version>
+    <version>1.55.0.0</version>
     <owners>bcurran3,dgalbraith</owners>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/manual/winaero-tweaker.install</packageSourceUrl>
     <title>Winaero Tweaker (Install)</title>
     <authors>Sergey Tkachenko</authors>
     <projectUrl>https://winaerotweaker.com</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9cecfce145d52fe2e4539dbe5b0ad47254b5620f/icons/winaero-tweaker.png</iconUrl>
-    <copyright>Copyright 2015-2022 winaero.com</copyright>
+    <copyright>Copyright 2015-2023 winaero.com</copyright>
     <licenseUrl>https://winaerotweaker.com/#eula</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>https://winaero.com/winaero-tweaker-faq</docsUrl>
@@ -33,7 +33,7 @@ Winaero Tweaker is a freeware all-in-one application that comes with dozens of o
 * Versions released after the package will cause checksums to fail.  If this is the case please contact the maintainer(s) and let them know the package requires updating.
 
     </description>
-    <releaseNotes>https://winaero.com/winaero-tweaker-1-40-is-here-with-new-features-and-fixes</releaseNotes>
+    <releaseNotes>https://winaero.com/winaero-tweaker-1-55</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/manual/winaero-tweaker.portable/README.md
+++ b/manual/winaero-tweaker.portable/README.md
@@ -3,7 +3,7 @@
 [![Software license ©Sergey Tkachenko](https://img.shields.io/badge/license-Copyright-lightgrey)](https://winaerotweaker.com/#eula)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-1.40.0.0-blue.svg)](https://winaerotweaker.com)
+[![Software version](https://img.shields.io/badge/Source-1.55.0.0-blue.svg)](https://winaerotweaker.com)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/winaero-tweaker.portable?label=Chocolatey)](https://chocolatey.org/packages/winaero-tweaker.portable)
 
 Winaero Tweaker is a freeware all-in-one application that comes with dozens of options for fine-grained tuning of various Windows settings and features.

--- a/manual/winaero-tweaker.portable/tools/chocolateyinstall.ps1
+++ b/manual/winaero-tweaker.portable/tools/chocolateyinstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
   unzipLocation = $toolsDir
   fileType      = 'zip'
   url           = 'https://winaerotweaker.com/download/winaerotweaker.zip'
-  checksum      = '137A628D2CA222BA42FCFB3696FEFE93012A13ECCD4F4408E7FFDAC33CD7D56F'
+  checksum      = '370095778b69f763af03e553f5a83b192c7183d098cb0d87350f66fb525573b8'
   checksumType  = 'sha256'
   options = @{
     headers = @{
@@ -21,7 +21,7 @@ Install-ChocolateyZipPackage @packageArgs
 $packageArgs = @{
   packageName    = $packageName
   fileType       = 'exe'
-  file           = '{0}\WinaeroTweaker-{1}-setup.exe' -f $toolsDir, $env:packageVersion
+  file           = '{0}\WinaeroTweaker-{1}.0-setup.exe' -f $toolsDir, $env:packageVersion
   silentArgs     = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /PORTABLE  /DIR=`"$toolsDir`""
   validExitCodes = @(0)
 }

--- a/manual/winaero-tweaker.portable/winaero-tweaker.portable.nuspec
+++ b/manual/winaero-tweaker.portable/winaero-tweaker.portable.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>winaero-tweaker.portable</id>
-    <version>1.40.0.0</version>
+    <version>1.55.0.0</version>
     <owners>bcurran3,dgalbraith</owners>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/manual/winaero-tweaker.portable</packageSourceUrl>
     <title>Winaero Tweaker (Portable)</title>
     <authors>Sergey Tkachenko</authors>
     <projectUrl>https://winaerotweaker.com</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9cecfce145d52fe2e4539dbe5b0ad47254b5620f/icons/winaero-tweaker.png</iconUrl>
-    <copyright>Copyright 2015-2022 winaero.com</copyright>
+    <copyright>Copyright 2015-2023 winaero.com</copyright>
     <licenseUrl>https://winaerotweaker.com/#eula</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>https://winaero.com/winaero-tweaker-faq</docsUrl>
@@ -34,7 +34,7 @@ Winaero Tweaker is a freeware all-in-one application that comes with dozens of o
 
     </description>
     <dependencies />
-    <releaseNotes>https://winaero.com/winaero-tweaker-1-40-is-here-with-new-features-and-fixes</releaseNotes>
+    <releaseNotes>https://winaero.com/winaero-tweaker-1-55</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/manual/winaero-tweaker/README.md
+++ b/manual/winaero-tweaker/README.md
@@ -3,7 +3,7 @@
 [![Software license ©Sergey Tkachenko](https://img.shields.io/badge/license-Copyright-lightgrey)](https://winaerotweaker.com/#eula)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-1.40.0.0-blue.svg)](https://winaerotweaker.com)
+[![Software version](https://img.shields.io/badge/Source-1.55.0.0-blue.svg)](https://winaerotweaker.com)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/winaero-tweaker?label=Chocolatey)](https://chocolatey.org/packages/winaero-tweaker)
 
 Winaero Tweaker is a freeware all-in-one application that comes with dozens of options for fine-grained tuning of various Windows settings and features.

--- a/manual/winaero-tweaker/winaero-tweaker.nuspec
+++ b/manual/winaero-tweaker/winaero-tweaker.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>winaero-tweaker</id>
-    <version>1.40.0.0</version>
+    <version>1.55.0.0</version>
     <owners>bcurran3,dgalbraith</owners>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/manual/winaero-tweaker</packageSourceUrl>
     <title>Winaero Tweaker</title>
     <authors>Sergey Tkachenko</authors>
     <projectUrl>https://winaerotweaker.com</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9cecfce145d52fe2e4539dbe5b0ad47254b5620f/icons/winaero-tweaker.png</iconUrl>
-    <copyright>Copyright 2015-2022 winaero.com</copyright>
+    <copyright>Copyright 2015-2023 winaero.com</copyright>
     <licenseUrl>https://winaerotweaker.com/#eula</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>https://winaero.com/winaero-tweaker-faq</docsUrl>
@@ -33,9 +33,9 @@ Winaero Tweaker is a freeware all-in-one application that comes with dozens of o
 * Versions released after the package will cause checksums to fail.  If this is the case please contact the maintainer(s) and let them know the package requires updating.
 
     </description>
-    <releaseNotes>https://winaero.com/winaero-tweaker-1-40-is-here-with-new-features-and-fixes</releaseNotes>
+    <releaseNotes>https://winaero.com/winaero-tweaker-1-55</releaseNotes>
     <dependencies>
-      <dependency id="winaero-tweaker.install" version="[1.40.0.0]" />
+      <dependency id="winaero-tweaker.install" version="[1.55.0.0]" />
     </dependencies>
   </metadata>
     <files>


### PR DESCRIPTION
Updated Winaero Tweaker package version to 1.55.0.0.

Standard package update to reflect the new version but the archive handling needed to be amended to reflect the inclusion of the patch version in the archive name.