### PR TITLE
(gh-486) Updated installer regex for  windows only

### DIFF
--- a/automatic/nushell/update.ps1
+++ b/automatic/nushell/update.ps1
@@ -7,8 +7,8 @@ $releases = "${domain}/nushell/nushell/releases/latest"
 
 $reChecksum  = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
 $reCopyright = '(?<=(Copyright\s(?<CopyrightFrom>[\d]{4})-))(?<CopyrightTo>[\d]{4})'
-$reInstall   = "(?<=\d\/|\s|')(?<Filename>(n.+w.+msi))"
-$rePortable  = "(?<=\d\/|\s|')(?<Filename>(n.+w.+zip))"
+$reInstall   = "(?<=\d\/|\s|')(?<Filename>(n.+x86_64.+w.+msi))"
+$rePortable  = "(?<=\d\/|\s|')(?<Filename>(n.+x86_64.+w.+zip))"
 $reVersion   = '(?<=v|\[|\/|-)(?<Version>([\d]+\.[\d]+\.[\d](\.(?=\d)\d+)?))'
 
 function global:au_BeforeUpdate {


### PR DESCRIPTION
The regex matching the packages for windows was no longer working as an additional set of packages for aarch64 arm had been introduced.  With the additional packages 2 sets of files were being matched (x86_64 and aarch64).

Updated the regex matching to ensure that only x86_64 packages were matched.