### PR TITLE
(gh-492) Modify regex in automatic update script

### DIFF
--- a/automatic/vscode-python/update.ps1
+++ b/automatic/vscode-python/update.ps1
@@ -7,12 +7,12 @@ $publisher = 'ms-python'
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "(copyright>)(.*)(<\/copyright>)"                            = "`${1}$($Latest.Copyright)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)(.* or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\README.md" = @{
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)(.* or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{


### PR DESCRIPTION
Modify regex in automatic update script to successfully match against versions with an -insider suffix.

Updates were failing as the addition of the -insider suffix to the required version caused regex matching to break.  The regex was amended to address this.