### PR TITLE
(gh-498) Updated to reflect iasl migration

### DIFF
--- a/automatic/iasl/README.md
+++ b/automatic/iasl/README.md
@@ -1,9 +1,9 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@fe977f362ae69c7f6ab164f87a9223d36538d3ed/icons/iasl.png" width="48" height="48" />iASL Compiler and ACPI Tools](https://community.chocolatey.org/packages/iasl)
 
-[![Software license](https://img.shields.io/badge/license-Intel-lightgrey.svg)](https://acpica.org/sites/acpica/files/licensing.txt)
+[![Software license](https://img.shields.io/badge/license-Intel-lightgrey.svg)](https://www.intel.com/content/www/us/en/developer/articles/license/acpica-licensing.html)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/source-v2022.03.31-blue.svg)](https://acpica.org/downloads/binary-tools)
+[![Software version](https://img.shields.io/badge/source-v2022.10.20-blue.svg)](https://www.intel.com/content/www/us/en/download/774881/acpi-component-architecture-downloads-windows-binary-tools.html)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/iasl?label=Chocolatey)](https://community.chocolatey.org/packages/iasl)
 
 The iASL compiler/disassembler is a fully-featured translator for the ACPI Source Language (ASL) and ACPI

--- a/automatic/iasl/iasl.nuspec
+++ b/automatic/iasl/iasl.nuspec
@@ -3,20 +3,20 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>iasl</id>
-    <version>2022.03.31</version>
+    <version>2022.10.20</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/iasl</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>iASL Compiler and ACPI Tools</title>
     <authors>Intel Corporation</authors>
-    <projectUrl>https://acpica.org</projectUrl>
+    <projectUrl>https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@fe977f362ae69c7f6ab164f87a9223d36538d3ed/icons/iasl.png</iconUrl>
     <copyright>Copyright (c) 1999 - 2022, Intel Corp.  All rights reserved.</copyright>
-    <licenseUrl>https://acpica.org/sites/acpica/files/licensing.txt</licenseUrl>
+    <licenseUrl>https://www.intel.com/content/www/us/en/developer/articles/license/acpica-licensing.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/acpica/acpica</projectSourceUrl>
-    <docsUrl>https://acpica.org/documentation</docsUrl>
+    <docsUrl>https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/documentation.html</docsUrl>
     <bugTrackerUrl>https://github.com/acpica/acpica/issues</bugTrackerUrl>
-    <mailingListUrl>https://lists.acpica.org/hyperkitty/list/devel@acpica.org</mailingListUrl>
+    <mailingListUrl>https://lists.linuxfoundation.org/mailman/listinfo/acpica-devel</mailingListUrl>
     <tags>iasl compiler decompiler asl aml acpi acpica intel</tags>
     <summary>ASL source language compiler, ACPI table compiler, and AML disassembler</summary>
     <description><![CDATA[

--- a/automatic/iasl/legal/LICENSE.txt
+++ b/automatic/iasl/legal/LICENSE.txt
@@ -2,7 +2,7 @@
  *
  * 1. Copyright Notice
  *
- * Some or all of this work - Copyright (c) 1999 - 2017, Intel Corp.
+ * Some or all of this work - Copyright (c) 1999 - 2023, Intel Corp.
  * All rights reserved.
  *
  * 2. License

--- a/automatic/iasl/legal/VERIFICATION.txt
+++ b/automatic/iasl/legal/VERIFICATION.txt
@@ -8,22 +8,22 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://acpica.org/downloads/binary-tools
+  https://www.intel.com/content/www/us/en/download/774881/acpi-component-architecture-downloads-windows-binary-tools.html
 
-and download the installer iasl-win-20220331.zip using the iASL compiler and Windows ACPI tools
-link in the Windows Binary Toos section of the page.
+and download the installer iasl-win-20221020_Signed.zip using the Download button
+on the page.
 
 Alternatively the build can be downloaded directly from
 
-  https://acpica.org/sites/acpica/files/iasl-win-20220331.zip
+  https://downloadmirror.intel.com/783546/iasl-win-20221020_Signed.zip
 
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 iasl-win-20220331.zip
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f iasl-win-20220331.zip
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 iasl-win-20221020_Signed.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f iasl-win-20221020_Signed.zip
 
-  File:     iasl-win-20220331.zip
+  File:     iasl-win-20221020_Signed.zip
   Type:     sha256
-  Checksum: E501C152DAF2D40763ABAA8F6923E690252BBE4F3F9718D2B20298BCA6CCC125
+  Checksum: 44b21aad479f3be710854cdc6c5072edcf0dbad36233172ffb7cc9b125cd54b7
 
-Contents of file LICENSE.txt is obtained from https://acpica.org/sites/acpica/files/licensing.txt
+Contents of file LICENSE.txt is obtained from https://github.com/acpica/acpica/blob/master/source/include/acpi.h

--- a/automatic/iasl/tools/chocolateyinstall.ps1
+++ b/automatic/iasl/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $toolsDir  = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 
-$archive = Join-Path $toolsDir 'iasl-win-20220331.zip'
+$archive = Join-Path $toolsDir 'iasl-win-20221020_Signed.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName

--- a/automatic/iasl/update.ps1
+++ b/automatic/iasl/update.ps1
@@ -2,10 +2,10 @@
 
 $ErrorActionPreference = 'Stop'
 
-$domain   = 'https://acpica.org'
-$releases = "${domain}/downloads/binary-tools"
+$releases  = 'https://www.intel.com/content/www/us/en/download/774881/acpi-component-architecture-downloads-windows-binary-tools.html'
+$userAgent = 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/W.X.Y.Z Safari/537.36'
 
-$reFile      = '(iasl-win-\d{8}\.zip)'
+$reFile      = '(?<Filename>iasl-win-\d{8}.*\.zip)'
 $reChecksum  = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
 $reCopyright = '(?<=(Copyright.+(?<CopyrightFrom>[\d]{4})\s-\s))(?<CopyrightTo>[\d]{4})'
 $reVersion   = '(?<=v)(?<Version>(\d{4}\.\d{2}\.\d{2}))'
@@ -36,10 +36,11 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
+  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases -UserAgent $userAgent
 
-  $url32      = $downloadPage.links | Where-Object href -match $reFile | Select-Object -expand href
-  $fileName32 = $url32 -split '/' | Select-Object -Last 1
+  $downloadPage.Content -match "(?<Url>https:\/\/.+$reFile)"
+  $url32      = $Matches.Url
+  $fileName32 = $Matches.Filename
 
   $fileName32 -match '(?<Year>\d{4})(?<Month>\d{2})(?<Day>\d{2})'
   $version = '{0}.{1}.{2}' -f $Matches.Year, $Matches.Month, $Matches.Day


### PR DESCRIPTION
The iasl pages were migrated from acpica.org to direct hosting on the Intel site.  This migration broke the existing package updates.

To address this the documentation and package download URLs were updated to refect the new location direct with Intel.