### PR TITLE
(gh-501) Modify update to reflect new artifacts

### DIFF
--- a/automatic/naps2.install/README.md
+++ b/automatic/naps2.install/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/cyanfish/naps2/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v6.1.2-blue)](https://github.com/cyanfish/naps2/releases/tag/v6.1.2)
+[![Software version](https://img.shields.io/badge/Source-v7.1.0-blue)](https://github.com/cyanfish/naps2/releases/tag/v7.1.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/naps2.install?label=Chocolatey)](https://chocolatey.org/packages/naps2.install)
 
 NAPS2 is a document scanning application with a focus on simplicity and ease of use. Scan your documents from WIA- and

--- a/automatic/naps2.install/legal/LICENSE.txt
+++ b/automatic/naps2.install/legal/LICENSE.txt
@@ -1,7 +1,7 @@
 ﻿NAPS2 (Not Another PDF Scanner 2)
 http://sourceforge.net/projects/naps2/
 
-Copyright 2009, 2012-2017 NAPS2 Contributors
+Copyright 2009-2022 NAPS2 Contributors
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/automatic/naps2.install/legal/VERIFICATION.txt
+++ b/automatic/naps2.install/legal/VERIFICATION.txt
@@ -8,21 +8,29 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/cyanfish/naps2/releases/tag/v6.1.2
+  https://github.com/cyanfish/naps2/releases/tag/v7.1.0
 
-and download the archive naps2-6.1.2-setup.msi using the links in the asset
-section of the page.
+and download the archive naps2-7.1.0-win-x86.msi or naps2-7.1.0-win-x64.msi using
+the links in the asset section of the page.
 
 Alternatively the build can be downloaded directly from
 
-  https://github.com/cyanfish/naps2/releases/download/v6.1.2/naps2-6.1.2-setup.msi
+  https://github.com/cyanfish/naps2/releases/download/v7.1.0/naps2-7.1.0-win-x86.msi
+  https://github.com/cyanfish/naps2/releases/download/v7.1.0/naps2-7.1.0-win-x64.msi
 
-2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 naps2-6.1.2-setup.msi
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f naps2-6.1.2-setup.msi
+2. The archives can be validated by comparing checksums
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 naps2-7.1.0-win-x86.msi
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f naps2-7.1.0-win-x86.msi
 
-  File:     naps2-6.1.2-setup.msi
-  Type:     sha256
-  Checksum: A3AE684694FEDBBC557208320DF571EABE5B4099A4D26C0AC00AAF6EBAB09238
+  File:       naps2-7.1.0-win-x86.msi
+  Type:       sha256
+  Checksum32: b694101d7d12b574a1caa774f5e42e82da6ba350a25bd72d437b0dca403de6ed
+
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 naps2-7.1.0-win-x64.msi
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f naps2-7.1.0-win-x64.msi
+
+  File:       naps2-7.1.0-win-x64.msi
+  Type:       sha256
+  Checksum64: cec4e565b141ac7f799f755844240b1302ca3983d2e5c8d344e12ef69c9f5eaf
 
 Contents of file LICENSE.txt is obtained from https://github.com/cyanfish/naps2/blob/master/LICENSE

--- a/automatic/naps2.install/naps2.install.nuspec
+++ b/automatic/naps2.install/naps2.install.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>naps2.install</id>
-    <version>6.1.2</version>
+    <version>7.1.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/naps2.install</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>NAPS2 (Not Another PDF Scanner 2) (Install)</title>
@@ -53,7 +53,7 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://github.com/cyanfish/naps2/releases/tag/v6.1.2</releaseNotes>
+    <releaseNotes>https://github.com/cyanfish/naps2/releases/tag/v7.1.0</releaseNotes>
     <dependencies>
       <dependency id="dotnetfx" version="4.8.0.0" />
     </dependencies>

--- a/automatic/naps2.install/tools/ChocolateyInstall.ps1
+++ b/automatic/naps2.install/tools/ChocolateyInstall.ps1
@@ -2,8 +2,6 @@
 
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
-$installer = Join-Path $toolsDir 'naps2-6.1.2-setup.msi'
-
 $silentArgs = '/quiet /qn /norestart'
 
 if ($pp.InstallDir) {
@@ -14,7 +12,8 @@ $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
   FileType       = 'msi'
   SoftwareName   = 'NAPS2'
-  File           = $installer
+  File           = Join-Path $toolsDir 'naps2-7.1.0-win-x86.msi'
+  File64         = Join-Path $toolsDir 'naps2-7.1.0-win-x64.msi'
   SilentArgs     = $silentArgs
   ValidExitCodes = @(0, 1641, 3010)
 }

--- a/automatic/naps2.install/update.ps1
+++ b/automatic/naps2.install/update.ps1
@@ -3,8 +3,10 @@
 $ErrorActionPreference = 'STOP'
 
 function global:au_BeforeUpdate {
-  $Latest.FileName32 = "$($Latest.FileNameInstall)"
-  $Latest.Url32      = "$($Latest.UrlInstall)"
+  $Latest.FileName32 = "$($Latest.FileNameInstall32)"
+  $Latest.Url32      = "$($Latest.UrlInstall32)"
+  $Latest.FileName64 = "$($Latest.FileNameInstall64)"
+  $Latest.Url64      = "$($Latest.UrlInstall64)"
 
   Get-RemoteFiles -Purge -NoSuffix
 }
@@ -21,15 +23,18 @@ function global:au_SearchReplace {
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "$($reChecksum)" = "$($Latest.Checksum32)"
-      "$($reInstall)"  = "$($Latest.FileName32)"
-      "$($reVersion)"  = "$($Latest.Version)"
+      "$($reChecksum32)" = "$($Latest.Checksum32)"
+      "$($reInstall32)"  = "$($Latest.FileName32)"
+      "$($reChecksum64)" = "$($Latest.Checksum64)"
+      "$($reInstall64)"  = "$($Latest.FileName64)"
+      "$($reVersion)"    = "$($Latest.Version)"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "$($reInstall)" = "$($Latest.FileName32)"
+      "$($reInstall32)" = "$($Latest.FileName32)"
+      "$($reInstall64)" = "$($Latest.FileName64)"
     }
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoReadme -NoCheckUrl

--- a/automatic/naps2.portable/README.md
+++ b/automatic/naps2.portable/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/cyanfish/naps2/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v6.1.2-blue)](https://github.com/cyanfish/naps2/releases/tag/v6.1.2)
+[![Software version](https://img.shields.io/badge/Source-v7.1.0-blue)](https://github.com/cyanfish/naps2/releases/tag/v7.1.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/naps2.portable?label=Chocolatey)](https://chocolatey.org/packages/naps2.portable)
 
 NAPS2 is a document scanning application with a focus on simplicity and ease of use. Scan your documents from WIA- and

--- a/automatic/naps2.portable/legal/LICENSE.txt
+++ b/automatic/naps2.portable/legal/LICENSE.txt
@@ -1,7 +1,7 @@
 ﻿NAPS2 (Not Another PDF Scanner 2)
 http://sourceforge.net/projects/naps2/
 
-Copyright 2009, 2012-2017 NAPS2 Contributors
+Copyright 2009-2022 NAPS2 Contributors
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/automatic/naps2.portable/legal/VERIFICATION.txt
+++ b/automatic/naps2.portable/legal/VERIFICATION.txt
@@ -8,21 +8,21 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/cyanfish/naps2/releases/tag/v6.1.2
+  https://github.com/cyanfish/naps2/releases/tag/v7.1.0
 
-and download the archive naps2-6.1.2-portable.7z using the links in the asset
+and download the archive naps2-7.1.0-win.zip using the links in the asset
 section of the page.
 
 Alternatively the build can be downloaded directly from
 
-  https://github.com/cyanfish/naps2/releases/download/v6.1.2/naps2-6.1.2-portable.7z
+  https://github.com/cyanfish/naps2/releases/download/v7.1.0/naps2-7.1.0-win.zip
 
 2. The archive can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 naps2-6.1.2-portable.7z
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f naps2-6.1.2-portable.7z
+  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 naps2-7.1.0-win.zip
+  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f naps2-7.1.0-win.zip
 
-  File:     naps2-6.1.2-portable.7z
+  File:     naps2-7.1.0-win.zip
   Type:     sha256
-  Checksum: 2B2EBB144716774505C8ABF6B121CBB2684BE9EA273299681178F1BC7C75E166
+  Checksum: bc629c2afdca52fa4398b82445c80bcf7fb498f733bade6ce5e1eff3cc7ad058
 
 Contents of file LICENSE.txt is obtained from https://github.com/cyanfish/naps2/blob/master/LICENSE

--- a/automatic/naps2.portable/naps2.portable.nuspec
+++ b/automatic/naps2.portable/naps2.portable.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>naps2.portable</id>
-    <version>6.1.2</version>
+    <version>7.1.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/naps2.portable</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>NAPS2 (Not Another PDF Scanner 2) (Portable)</title>
     <authors>Ben Olden-Cooligan</authors>
     <projectUrl>https://www.naps2.com</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@c809e86a58e0c324229204801a3ebecd82edbfa7/icons/naps2.png</iconUrl>
-    <copyright>Copyright 2009, 2012-2021 NAPS2 Contributors</copyright>
+    <copyright>Copyright 2009-2022 NAPS2 Contributors</copyright>
     <licenseUrl>https://github.com/cyanfish/naps2/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/cyanfish/naps2</projectSourceUrl>

--- a/automatic/naps2.portable/tools/chocolateyInstall.ps1
+++ b/automatic/naps2.portable/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
-$archive  = Join-Path $toolsDir 'naps2-6.1.2-portable.7z'
+$archive  = Join-Path $toolsDir 'naps2-7.1.0-win.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName

--- a/automatic/naps2.portable/update.ps1
+++ b/automatic/naps2.portable/update.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = 'STOP'
 
 function global:au_BeforeUpdate {
   $Latest.FileName32 = "$($Latest.FileNamePortable)"
-  $Latest.FileType   = '7z'
+  $Latest.FileType   = 'zip'
   $Latest.Url32      = "$($Latest.UrlPortable)"
 
   Get-RemoteFiles -Purge -NoSuffix
@@ -33,4 +33,4 @@ function global:au_SearchReplace {
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoReadme -NoCheckUrl

--- a/automatic/naps2/README.md
+++ b/automatic/naps2/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/GPLv2-blue.svg)](https://github.com/cyanfish/naps2/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v6.1.2-blue)](https://github.com/cyanfish/naps2/releases/tag/v6.1.2)
+[![Software version](https://img.shields.io/badge/Source-v7.1.0-blue)](https://github.com/cyanfish/naps2/releases/tag/v7.1.0)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/naps2?label=Chocolatey)](https://chocolatey.org/packages/naps2)
 
 NAPS2 is a document scanning application with a focus on simplicity and ease of use. Scan your documents from WIA- and

--- a/automatic/naps2/naps2.nuspec
+++ b/automatic/naps2/naps2.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>naps2</id>
-    <version>6.1.2</version>
+    <version>7.1.0</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/naps2</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>NAPS2 (Not Another PDF Scanner 2)</title>
     <authors>Ben Olden-Cooligan</authors>
     <projectUrl>https://www.naps2.com</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@c809e86a58e0c324229204801a3ebecd82edbfa7/icons/naps2.png</iconUrl>
-    <copyright>Copyright 2009, 2012-2019 NAPS2 Contributors</copyright>
+    <copyright>Copyright 2009-2022 NAPS2 Contributors</copyright>
     <licenseUrl>https://github.com/cyanfish/naps2/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/cyanfish/naps2</projectSourceUrl>
@@ -47,9 +47,9 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://github.com/cyanfish/naps2/releases/tag/v6.1.2</releaseNotes>
+    <releaseNotes>https://github.com/cyanfish/naps2/releases/tag/v7.1.0</releaseNotes>
     <dependencies>
-      <dependency id="naps2.install" version="[6.1.2]" />
+      <dependency id="naps2.install" version="[7.1.0]" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/naps2/update.ps1
+++ b/automatic/naps2/update.ps1
@@ -5,10 +5,12 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://github.com'
 $releases = "${domain}/cyanfish/naps2/releases/latest"
 
-$reChecksum     = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
+$reChecksum32   = '(?<=Checksum32:\s*)((?<Checksum>([^\s].+)))'
+$reChecksum64   = '(?<=Checksum64:\s*)((?<Checksum>([^\s].+)))'
 $reCopyright    = '(?<=(Copyright.+(?<CopyrightFrom>[\d]{4})-))(?<CopyrightTo>[\d]{4})'
-$reInstall      = "(?<=\d\/|\s|')(?<Filename>(n.+msi))"
-$rePortable     = "(?<=\d\/|\s|')(?<Filename>(n.+7z))"
+$reInstall32    = "(?<=\d\/|\s|')(?<Filename>(n.+x86\.msi))"
+$reInstall64    = "(?<=\d\/|\s|')(?<Filename>(n.+x64\.msi))"
+$rePortable     = "(?<=\d\/|\s|')(?<Filename>(n.+zip))"
 $reVersion      = '(?<=v|\[)(?<Version>([\d]+\.[\d]+\.[\d]+\.?[\d]*))'
 
 function global:au_BeforeUpdate {
@@ -33,8 +35,10 @@ function global:au_GetLatest {
   $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
   $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
 
-  $urlInstall      = $assetsPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
-  $fileNameInstall = $urlInstall -split '/' | select-object -last 1
+  $urlInstall32      = $assetsPage.links | where-object href -match $reInstall32 | select-object -expand href | foreach-object { $domain + $_ }
+  $fileNameInstall32 = $urlInstall32 -split '/' | select-object -last 1
+  $urlInstall64      = $assetsPage.links | where-object href -match $reInstall64 | select-object -expand href | foreach-object { $domain + $_ }
+  $fileNameInstall64 = $urlInstall64 -split '/' | select-object -last 1
 
   $urlPortable      = $assetsPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
   $fileNamePortable = $urlPortable -split '/' | select-object -last 1
@@ -43,12 +47,14 @@ function global:au_GetLatest {
   $version    = $urlPortable -match $reVersion | foreach-object { $Matches.Version }
 
   return @{
-    UrlInstall       = $urlInstall
-    FileNameInstall  = $fileNameInstall
-    UrlPortable      = $urlPortable
-    FileNamePortable = $fileNamePortable
-    UpdateYear       = $updateYear
-    Version          = $version
+    UrlInstall32      = $urlInstall32
+    FileNameInstall32 = $fileNameInstall32
+    UrlInstall64      = $urlInstall64
+    FileNameInstall64 = $fileNameInstall64
+    UrlPortable       = $urlPortable
+    FileNamePortable  = $fileNamePortable
+    UpdateYear        = $updateYear
+    Version           = $version
   }
 }
 


### PR DESCRIPTION
Source package artifacts had been updated to have new names in the 7.1 series with the introduction of discrete 32 and 64-bit installers and the modification of the archive names to include -win.

Modified the automatic updater to reflect the new artifacts and naming.