### PR TITLE
(gh-503) Remove MathJax from documentation

### DIFF
--- a/automatic/sqlean-shell/README.md
+++ b/automatic/sqlean-shell/README.md
@@ -9,14 +9,6 @@
 sqlean shell is SQLite shell bundled with a collection of [essential extensions](https://github.com/nalgeon/sqlean#main-set)
 ranging from regular expressions and math statistics to file I/O and dynamic SQL.
 
-sqlean = sqlite +
-$\begin{pmatrix}
-  crypto & ipaddr & text \\
-  define & math & unicode \\
-  fileio & regexp & uuid \\
-  fuzzy & stats & vsv
-\end{pmatrix}$
-
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@ee024e32bd615c9597654203de1907c6533027f8/automatic/sqlean-shell/screenshot.png)
 
 ## Package Parameters

--- a/automatic/sqlean-shell/sqlean-shell.nuspec
+++ b/automatic/sqlean-shell/sqlean-shell.nuspec
@@ -23,14 +23,6 @@
 sqlean shell is SQLite shell bundled with a collection of [essential extensions](https://github.com/nalgeon/sqlean#main-set)
 ranging from regular expressions and math statistics to file I/O and dynamic SQL.
 
-sqlean = sqlite +
-$\begin{pmatrix}
-  crypto & ipaddr & text \\
-  define & math & unicode \\
-  fileio & regexp & uuid \\
-  fuzzy & stats & vsv
-\end{pmatrix}$
-
 ![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@ee024e32bd615c9597654203de1907c6533027f8/automatic/sqlean-shell/screenshot.png)
 
 ## Package Parameters


### PR DESCRIPTION
MathJax had been used to document the package but the MathJax was not being rendered.

Removed the MathJax to address this.