### PR TITLE
(gh-505) Correct package documentation

### DIFF
--- a/automatic/sqlite-shell-x64/README.md
+++ b/automatic/sqlite-shell-x64/README.md
@@ -1,4 +1,4 @@
-# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9bd285a368d17e0f4fd8763fdf679d621b4a9657/icons/sqlite-shell-x64.png" width="48" height="48" />sqlean-shell-x64 - 64-bit SQLite shell](https://chocolatey.org/packages/sqlite-shell-x64)
+# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9bd285a368d17e0f4fd8763fdf679d621b4a9657/icons/sqlite-shell-x64.png" width="48" height="48" />sqlite-shell-x64 - 64-bit SQLite shell](https://chocolatey.org/packages/sqlite-shell-x64)
 
 [![Software license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/nalgeon/sqlite/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
@@ -31,22 +31,3 @@ e.g. `choco install -y sqlite-shell-x64 --package-parameters="/AddToDesktop /Use
 * sqlite-shell-x64 is only available as a 64-bit version.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
-
-sqlean = sqlite +
-$\begin{pmatrix}
-  crypto & ipaddr & text \\
-  define & math & unicode \\
-  fileio & regexp & uuid \\
-  fuzzy & stats & vsv
-\end{pmatrix}$
-
-![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@TODO/automatic/sqlean-shell/screenshot.png)
-
-
-## Notes
-
-* sqlean-shell is only available as a 64-bit version.
-* This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
-  If you find it is out of date by more than a day or two, please contact
-  the maintainer(s) and let them know the package is no longer updating
-  correctly.

--- a/automatic/sqlite-shell-x64/sqlite-shell-x64.nuspec
+++ b/automatic/sqlite-shell-x64/sqlite-shell-x64.nuspec
@@ -4,34 +4,29 @@
   <metadata>
     <id>sqlite-shell-x64</id>
     <version>3.43.0</version>
-    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/sqlean-shell-x64</packageSourceUrl>
+    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/sqlite-shell-x64</packageSourceUrl>
     <owners>dgalbraith</owners>
-    <title>SQLite shell bundled with essential sqlean extensions</title>
+    <title>SQLite shell 64-bit</title>
     <authors>Anton Zhiyanov</authors>
     <projectUrl>https://github.com/nalgeon/sqlite/blob/main/README.md</projectUrl>
-    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9bd285a368d17e0f4fd8763fdf679d621b4a9657/icons/sqlean-shell-x64.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9bd285a368d17e0f4fd8763fdf679d621b4a9657/icons/sqlite-shell-x64.png</iconUrl>
     <copyright>Copyright 2021 Anton Zhiyanov</copyright>
     <licenseUrl>https://github.com/nalgeon/sqlite/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/nalgeon/sqlite</projectSourceUrl>
-    <docsUrl>https://github.com/nalgeon/sqlean/blob/main/README.md</docsUrl>
+    <docsUrl>https://github.com/nalgeon/sqlite/blob/main/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/nalgeon/sqlite/issues</bugTrackerUrl>
-    <tags>sqlite sqlean sql db database embedded bundled-extensions</tags>
-    <summary>SQLite shell bundled with essential extensions</summary>
+    <tags>sqlite sql db database embedded 64-bit</tags>
+    <summary>SQLite shell 64-bit executable</summary>
     <description><![CDATA[
 
-sqlean shell is SQLite shell bundled with a collection of [essential extensions](https://github.com/nalgeon/sqlean#main-set)
-ranging from regular expressions and math statistics to file I/O and dynamic SQL.
+SQLite Shell is a command-line shell that allows the user to manually enter and
+execute SQL statements against an SQLite database.
 
-sqlean = sqlite +
-$\begin{pmatrix}
-  crypto & ipaddr & text \\
-  define & math & unicode \\
-  fileio & regexp & uuid \\
-  fuzzy & stats & vsv
-\end{pmatrix}$
+Current builds from Hwaci are only provided in 32-bit versions - this package
+addresses that and provides a 64-bit Windows build.
 
-![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9bd285a368d17e0f4fd8763fdf679d621b4a9657/automatic/sqlean-shell/screenshot.png)
+![screenshot](https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@9bd285a368d17e0f4fd8763fdf679d621b4a9657/automatic/sqlite-shell-x64/screenshot.png)
 
 ## Package Parameters
 
@@ -49,9 +44,7 @@ e.g. `choco install -y sqlite-shell-x64 --package-parameters="/AddToDesktop /Use
 
 * sqlite-shell-x64 is only available as a 64-bit version.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
-  If you find it is out of date by more than a day or two, please contact
-  the maintainer(s) and let them know the package is no longer updating
-  correctly.
+  If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
     <releaseNotes>https://github.com/nalgeon/sqlite/releases/tag/3.43.0</releaseNotes>


### PR DESCRIPTION
Package documentation was incorrect with references to another package and extraneous text had been included.

Updated all package references and removed the extraneous text.