### PR TITLE
(gh-513) Exclude full release files

### DIFF
--- a/automatic/nushell/update.ps1
+++ b/automatic/nushell/update.ps1
@@ -7,8 +7,8 @@ $releases = "${domain}/nushell/nushell/releases/latest"
 
 $reChecksum  = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
 $reCopyright = '(?<=(Copyright\s(?<CopyrightFrom>[\d]{4})-))(?<CopyrightTo>[\d]{4})'
-$reInstall   = "(?<=\d\/|\s|')(?<Filename>(n.+x86_64.+w.+msi))"
-$rePortable  = "(?<=\d\/|\s|')(?<Filename>(n.+x86_64.+w.+zip))"
+$reInstall   = "(?<=\d\/|\s|')(?<Filename>(n.+x86_64.+w.+msvc\.msi))"
+$rePortable  = "(?<=\d\/|\s|')(?<Filename>(n.+x86_64.+w.+msvc\.zip))"
 $reVersion   = '(?<=v|\[|\/|-)(?<Version>([\d]+\.[\d]+\.[\d](\.(?=\d)\d+)?))'
 
 function global:au_BeforeUpdate {


### PR DESCRIPTION
The package build was failing as new release artifacts had been introduced.

Updated the regex matching on the package build to ensure that the full release files `*-msvc-full.msi` were excluded and only the default `*msvc.msi` files were matched.