### PR TITLE
(gh-510) Handle 64-bit tool package

### DIFF
--- a/automatic/sqlite.analyzer/README.md
+++ b/automatic/sqlite.analyzer/README.md
@@ -33,5 +33,12 @@ utilization of a particular database file.
 
 * The `sqlite3_analyzer.exe` program is a [TCL](http://www.tcl.tk/) program that uses the [dbstat virtual table](https://www.sqlite.org/dbstat.html)
   to gather information about the database file and then format that information neatly.
+* Current versions of sqlite analyzer provide 64-bit support only - for a 32-bit version use [sqlite.analyzer 3.43.2](https://chocolatey.org/packages/sqlite.analyzer/3.43.2).
+
+  ```powershell
+  choco install sqlite.analyzer --version 3.43.2
+  choco pin add -n=sqlite.analyzer --version 3.43.2
+  ```
+
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/sqlite.analyzer/sqlite.analyzer.nuspec
+++ b/automatic/sqlite.analyzer/sqlite.analyzer.nuspec
@@ -48,6 +48,13 @@ utilization of a particular database file.
 
 * The `sqlite3_analyzer.exe` program is a [TCL](http://www.tcl.tk/) program that uses the [dbstat virtual table](https://www.sqlite.org/dbstat.html)
   to gather information about the database file and then format that information neatly.
+* Current versions of sqlite analyzer provide 64-bit support only - for a 32-bit version use [sqlite.analyzer 3.43.2](https://chocolatey.org/packages/sqlite.analyzer/3.43.2).
+
+  ```powershell
+  choco install sqlite.analyzer --version 3.43.2
+  choco pin add -n=sqlite.analyzer --version 3.43.2
+  ```
+
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 

--- a/automatic/sqlite.shell/README.md
+++ b/automatic/sqlite.shell/README.md
@@ -12,5 +12,12 @@ SQLite Shell is a command-line shell that allows the user to manually enter and 
 
 ## Notes
 
+* Current versions of sqlite shell provide 64-bit support only - for a 32-bit version use [sqlite.shell 3.43.2](https://chocolatey.org/packages/sqlite.shell/3.43.2).
+
+  ```powershell
+  choco install sqlite.shell --version 3.43.2
+  choco pin add -n=sqlite.shell --version 3.43.2
+  ```
+
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/sqlite.shell/sqlite.shell.nuspec
+++ b/automatic/sqlite.shell/sqlite.shell.nuspec
@@ -27,6 +27,13 @@ SQLite Shell is a command-line shell that allows the user to manually enter and 
 
 ## Notes
 
+* Current versions of sqlite shell provide 64-bit support only - for a 32-bit version use [sqlite.shell 3.43.2](https://chocolatey.org/packages/sqlite.shell/3.43.2).
+
+  ```powershell
+  choco install sqlite.shell --version 3.43.2
+  choco pin add -n=sqlite.shell --version 3.43.2
+  ```
+
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 

--- a/automatic/sqlite.shell/update.ps1
+++ b/automatic/sqlite.shell/update.ps1
@@ -10,13 +10,13 @@ $toolsDir = Join-Path $(Split-Path -parent $MyInvocation.MyCommand.Definition) '
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
 
-  $archive = Join-Path $toolsDir $Latest.FileName32 
+  $archive = Join-Path $toolsDir $Latest.FileName64
 
   Expand-Archive -Path $archive -DestinationPath $toolsDir
 
   $executable = Get-ChildItem -Path $toolsDir 'sqlite?.exe' -Recurse
   $Latest.Executable = $executable.Name
-  $Latest.Checksum32 = (Get-Filehash -algorithm sha256 $executable.FullName).Hash
+  $Latest.Checksum64 = (Get-Filehash -algorithm sha256 $executable.FullName).Hash
 
   Move-Item -Path $executable.FullName $toolsDir
 
@@ -31,9 +31,9 @@ function global:au_SearchReplace {
      }
 
     ".\legal\VERIFICATION.txt" = @{
-      '(sqlite\d.exe)'          = "$($Latest.Executable)"
-      '(sqlite-.+win32.+\.zip)' = "$($Latest.Filename32)"
-      '(Checksum:\s*)(.+)'      = "`${1}$($Latest.Checksum32)"
+      '(sqlite\d.exe)'        = "$($Latest.Executable)"
+      '(sqlite-.+win.+\.zip)' = "$($Latest.Filename64)"
+      '(Checksum:\s*)(.+)'    = "`${1}$($Latest.Checksum64)"
     }
   }
 }
@@ -42,9 +42,9 @@ function getVersion {
   param ([string] $rawVersion)
 
   # SQLite versions are encoded so that filenames sort in order of increasing version number when viewed using "ls".
-  # For version 3.X.Y the filename encoding is 3XXYY00. For branch version 3.X.Y.Z, the encoding is 3XXYYZZ. 
+  # For version 3.X.Y the filename encoding is 3XXYY00. For branch version 3.X.Y.Z, the encoding is 3XXYYZZ.
   $rawVersion -match '(?<Series>[\d])(?<Major>[\d]{2})(?<Minor>[\d]{2})(?<Patch>[\d]{2})' | Out-Null
-  
+
   $series = $Matches.Series
   $major  = $Matches.Major
   $minor  = $Matches.Minor
@@ -59,7 +59,7 @@ function getVersion {
     $patch = $patch.substring(1,1)
   }
 
-  # a version contains the branch element only if it is non-zero 
+  # a version contains the branch element only if it is non-zero
   if ($rawVersion -match '[\d]{5}00') {
     $version = '{0}.{1}.{2}'     -f $series, $major, $minor
   } else {
@@ -72,18 +72,18 @@ function getVersion {
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-  $downloadPage.Content -match '(?<DownloadUrl>(([\d]{4}\/(?<FileName>(.+tools-win32.+(?<Version>([\d]{7}))\.zip)))))'
+  $downloadPage.Content -match '(?<DownloadUrl>(([\d]{4}\/(?<FileName>(.+tools-win-x64.+(?<Version>([\d]{7}))\.zip)))))'
 
-  $url32      = ("{0}/{1}" -f $base, $Matches.DownloadUrl) 
-  $fileName32 = $matches.FileName
+  $url64      = ("{0}/{1}" -f $base, $Matches.DownloadUrl)
+  $fileName64 = $matches.FileName
   $rawVersion = $Matches.Version
 
   $version = getVersion($rawVersion)
 
   return @{
     FileType   = 'zip'
-    FileName32 = $filename32
-    Url32      = $url32
+    FileName64 = $filename64
+    Url64      = $url64
     Version    = $version
   }
 }


### PR DESCRIPTION
The tools package for sqlite has been updated to be provided as a 64-bit binary with the 3.43.0 release.  The sqlite tools package build were breaking due to this.

Modified the update and install scripts to be able to correctly retrieve and use the 64-bit versions as opposed to the 32-bit ones.  Also modified the documentation to reflect the 64-bit nature of the binaries and provide instructions on retrieving and pinning the last 32-bit versions 3.43.2.