### PR TITLE
(gh-519) Use MSI GUID to fix Remote Desktop pkg

### DIFF
--- a/automatic/remote-desktop-client/tools/chocolateyInstall.ps1
+++ b/automatic/remote-desktop-client/tools/chocolateyInstall.ps1
@@ -57,7 +57,18 @@ Set-ItemProperty -Path $registryPath -Name $name -Value $value -Type DWORD -Forc
 # x64 = 37482C7A-E958-455E-938E-0692B5C28708
 # x86 = 74E5B442-57F5-4097-95EA-38E8DBA1EBF1
 
-$installLocation = (Get-WmiObject -Class Win32_Product -Filter 'IdentifyingNumber like "{37482C7A-E958-455E-938E-0692B5C28708}" OR IdentifyingNumber like "{74E5B442-57F5-4097-95EA-38E8DBA1EBF1}"').InstallLocation
+$localisedName = Get-ItemPropertyValue "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{37482C7A-E958-455E-938E-0692B5C28708}\" -Name "DisplayName" -ErrorAction SilentlyContinue
+
+if($localisedName -eq $Null){
+	$displayName = Get-ItemPropertyValue "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{74E5B442-57F5-4097-95EA-38E8DBA1EBF1}\" -Name "DisplayName" -ErrorAction SilentlyContinue
+}
+
+if($localisedName -eq $Null){
+	throw "The package MSI GUID was not found in registry!"
+}
+
+$uninstallKey    = Get-UninstallRegistryKey -SoftwareName $localisedName
+$installLocation = $uninstallKey.InstallLocation
 
 Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
   Install-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName

--- a/automatic/remote-desktop-client/tools/chocolateyInstall.ps1
+++ b/automatic/remote-desktop-client/tools/chocolateyInstall.ps1
@@ -52,8 +52,12 @@ if (-Not (Test-Path -Path $registryPath)) {
 
 Set-ItemProperty -Path $registryPath -Name $name -Value $value -Type DWORD -Force | Out-Null
 
-$uninstallKey    = Get-UninstallRegistryKey -SoftwareName $packageArgs.SoftwareName
-$installLocation = $uninstallKey.InstallLocation
+
+# get install location based on the MSI GUID of the x64 OR x86 version of the app
+# x64 = 37482C7A-E958-455E-938E-0692B5C28708
+# x86 = 74E5B442-57F5-4097-95EA-38E8DBA1EBF1
+
+$installLocation = (Get-WmiObject -Class Win32_Product -Filter 'IdentifyingNumber like "{37482C7A-E958-455E-938E-0692B5C28708}" OR IdentifyingNumber like "{74E5B442-57F5-4097-95EA-38E8DBA1EBF1}"').InstallLocation
 
 Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
   Install-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName

--- a/automatic/remote-desktop-client/tools/chocolateyUninstall.ps1
+++ b/automatic/remote-desktop-client/tools/chocolateyUninstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$packageSearch  = 'Remote Desktop'
+$localisedName = $installLocation = (Get-WmiObject -Class Win32_Product -Filter 'IdentifyingNumber like "{37482C7A-E958-455E-938E-0692B5C28708}" OR IdentifyingNumber like "{74E5B442-57F5-4097-95EA-38E8DBA1EBF1}"').Name
 $silentArgs     = '/qn /norestart'
 $validExitCodes = @(0, 1614, 1641, 3010)
 
-$uninstallKey = Get-UninstallRegistryKey -SoftwareName $packageSearch
+$uninstallKey = Get-UninstallRegistryKey -SoftwareName $localisedName
 
 if ($null -ne $uninstallKey) {
   $installLocation = $uninstallKey.InstallLocation

--- a/automatic/remote-desktop-client/tools/chocolateyUninstall.ps1
+++ b/automatic/remote-desktop-client/tools/chocolateyUninstall.ps1
@@ -1,8 +1,23 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$localisedName = $installLocation = (Get-WmiObject -Class Win32_Product -Filter 'IdentifyingNumber like "{37482C7A-E958-455E-938E-0692B5C28708}" OR IdentifyingNumber like "{74E5B442-57F5-4097-95EA-38E8DBA1EBF1}"').Name
+
+
 $silentArgs     = '/qn /norestart'
 $validExitCodes = @(0, 1614, 1641, 3010)
+
+# get localised name based on the MSI GUID of the x64 OR x86 version of the app
+# x64 = 37482C7A-E958-455E-938E-0692B5C28708
+# x86 = 74E5B442-57F5-4097-95EA-38E8DBA1EBF1
+
+$localisedName = Get-ItemPropertyValue "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{37482C7A-E958-455E-938E-0692B5C28708}\" -Name "DisplayName" -ErrorAction SilentlyContinue
+
+if($localisedName -eq $Null){
+	$displayName = Get-ItemPropertyValue "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{74E5B442-57F5-4097-95EA-38E8DBA1EBF1}\" -Name "DisplayName" -ErrorAction SilentlyContinue
+}
+
+if($localisedName -eq $Null){
+	throw "The package MSI GUID was not found in registry!"
+}
 
 $uninstallKey = Get-UninstallRegistryKey -SoftwareName $localisedName
 


### PR DESCRIPTION
This fixes the broken Remote Desktop package install and uninstall process on non-English localised systems.

I've chosen to use `Get-WmiObject` to query for the information about app location for install purposes and localised name for uninstall purposes (as the returned object does not contain uninstall string).