### PR TITLE
Add OpenSSL as default installation option to be aligned with documentation

### DIFF
--- a/automatic/openvpn/tools/chocolateyInstall.ps1
+++ b/automatic/openvpn/tools/chocolateyInstall.ps1
@@ -80,7 +80,7 @@ if ($pp.count -gt 0) {
   }
 } else {
   Write-Verbose('No parameters supplied - constructing a default parameter set')
-  $local = @('OpenVPN.GUI','OpenVPN.Documentation','OpenVPN.SampleCfg','OpenVPN','OpenVPN.GUI.OnLogon','Drivers.OvpnDco', 'Drivers.TAPWindows6','Drivers','Drivers.Wintun')
+  $local = @('OpenVPN.GUI','OpenVPN.Documentation','OpenVPN.SampleCfg','OpenVPN','OpenVPN.GUI.OnLogon','Drivers.OvpnDco','Drivers.TAPWindows6','Drivers','Drivers.Wintun','OpenSSL')
 }
 
 $silentArgs += " ADDLOCAL=`"{0}`"" -f ($local -join ",")


### PR DESCRIPTION
The OpenVPN readme file claims that OpenSSL is installed in case no installation parameters are provided. However, I noticed that this is not the case according to the Chocolatey installation script. This pull request adds the `OpenSSL` parameter which includes OpenSSL during the installation to ensure the installation script is in line with documentation.

https://github.com/dgalbraith/chocolatey-packages/blob/3f5827f0655055c8f460fbaaab375db3c98b868a/automatic/openvpn/README.md?plain=1#L53-L55
https://github.com/dgalbraith/chocolatey-packages/blob/3f5827f0655055c8f460fbaaab375db3c98b868a/automatic/openvpn/tools/chocolateyInstall.ps1#L81-L84

