### PR TITLE
(GH-528) Update the Office Deployment Tool to v2403 build 17531.20046

### DIFF
--- a/manual/office365proplus/Office365ProPlus.nuspec
+++ b/manual/office365proplus/Office365ProPlus.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>office365proplus</id>
-    <version>16731.20354</version>
+    <version>17531.20046</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/manual/office365proplus</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Office 365 Proofessional Plus</title>
@@ -38,6 +38,7 @@ e.g. `choco install office365proplus --params '/Language:de-de'`
 
 ## Notes
 
+* Office 365 Professional requires Windows 10 or newer.
 * This package is  manually updated.
 * If the package does not represent the latest version please contact the maintainer(s) and let them know the package requires updating.
 

--- a/manual/office365proplus/README.md
+++ b/manual/office365proplus/README.md
@@ -24,5 +24,6 @@ e.g. `choco install office365proplus --params '/Language:de-de'`
 
 ## Notes
 
+* Office 365 Professional requires Windows 10 or newer.
 * This package is  manually updated.
 * If the package does not represent the latest version please contact the maintainer(s) and let them know the package requires updating.

--- a/manual/office365proplus/tools/chocolateyInstall.ps1
+++ b/manual/office365proplus/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$script                     = $MyInvocation.MyCommand.Definition
-$packageName                = 'Office365ProPlus'
-$configFile                 = Join-Path $(Split-Path -parent $script) 'configuration.xml'
-$configFile64               = Join-Path $(Split-Path -parent $script) 'configuration64.xml'
-$bitCheck                   = Get-ProcessorBits
-$forceX86                   = $env:chocolateyForceX86
-$configurationFile          = if ($BitCheck -eq 32 -Or $forceX86) { $configFile } else { $configFile64 }
-$officetempfolder           = Join-Path $env:Temp 'chocolatey\Office365ProPlus'
+$script            = $MyInvocation.MyCommand.Definition
+$packageName       = 'Office365ProPlus'
+$configFile        = Join-Path $(Split-Path -parent $script) 'configuration.xml'
+$configFile64      = Join-Path $(Split-Path -parent $script) 'configuration64.xml'
+$bitCheck          = Get-ProcessorBits
+$forceX86          = $env:chocolateyForceX86
+$configurationFile = if ($BitCheck -eq 32 -Or $forceX86) { $configFile } else { $configFile64 }
+$officetempfolder  = Join-Path $env:Temp 'chocolatey\Office365ProPlus'
 
 $pp = Get-PackageParameters
 $configPath = $pp["ConfigPath"]
@@ -44,15 +44,15 @@ else
     Write-Output 'No language specified. Defaulting to OS language.'
 }
 
-$packageArgs                = @{
-    packageName             = 'Office365DeploymentTool'
-    fileType                = 'exe'
-    url                     = 'https://download.microsoft.com/download/2/7/A/27AF1BE6-DD20-4CB4-B154-EBAB8A7D4A7E/officedeploymenttool_16731-20354.exe'
-    checksum                = 'f37ee507114362407a7a7ff90acca1d3683ad105c2a4830b71b0de651d6eb18f'
-    checksumType            = 'sha256'
-    softwareName            = 'Microsoft Office 365 ProPlus*'
-    silentArgs              = "/extract:`"$officetempfolder`" /log:`"$officetempfolder\OfficeInstall.log`" /quiet /norestart"
-    validExitCodes          = @(
+$packageArgs = @{
+    packageName    = 'Office365DeploymentTool'
+    fileType       = 'exe'
+    url            = 'https://download.microsoft.com/download/2/7/A/27AF1BE6-DD20-4CB4-B154-EBAB8A7D4A7E/officedeploymenttool_17531-20046.exe'
+    checksum       = '0f9e6df376853154e05d81e2550183ed621ec97fc3f0c290666683a057086b92'
+    checksumType   = 'sha256'
+    softwareName   = 'Microsoft Office 365 ProPlus*'
+    silentArgs     = "/extract:`"$officetempfolder`" /log:`"$officetempfolder\OfficeInstall.log`" /quiet /norestart"
+    validExitCodes = @(
         0, # success
         3010, # success, restart required
         2147781575, # pending restart required


### PR DESCRIPTION
* Updated the Office Deployment Tool for Office 365 Pro to v2403 build 17531.20046.
* Updated documentation to reflect that Windows 2010 or later is reuqired.