### PR TITLE
(gh-534) Upgrade Chocolatey in build images

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,7 +51,9 @@ init:
 install:
 - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
 - ps: $PSVersionTable
+- choco upgrade chocolatey -y --no-progress
 - git --version
+- choco --version
 - ps: |
     git clone -q https://github.com/majkinetor/au.git $Env:TEMP/au
     . "$Env:TEMP/au/scripts/Install-AU.ps1" $Env:au_version


### PR DESCRIPTION
Appveyor Windows build images are pre-installed with Chocolatey 1.4.0.  This was causing issues due to the change in semantic versioning introduced in 2.0 - versions were not being correctly constructed.

Added build configuration to upgrade Chocolatey to latest version in the initial build setup.