### PR TITLE
(gh-543) Modify regular expressions to match expected filename

### DIFF
--- a/automatic/prime95/legal/VERIFICATION.txt
+++ b/automatic/prime95/legal/VERIFICATION.txt
@@ -10,19 +10,19 @@ be verified by:
 
   https://www.mersenne.org/download/
 
-and download the package p95v308b15.win32.zip or p95v308b17.win64.zip using the
+and download the package p95v308b17.win32.zip or p95v308b17.win64.zip using the
 links in the relevant section of the page.
 
 Alternatively the packages can be downloaded directly from
 
-  http://www.mersenne.org/ftp_root/gimps/p95v308b15.win32.zip
-  http://www.mersenne.org/ftp_root/gimps/p95v308b17.win64.zip
+  https://www.mersenne.org/download/software/v30/30.8/p95v308b17.win32.zip
+  https://www.mersenne.org/download/software/v30/30.8/p95v308b17.win64.zip
 
 2. The package can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash p95v308b15.win32.zip
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f p95v308b15.win32.zip
+  - Use powershell function 'Get-Filehash' - Get-Filehash p95v308b17.win32.zip
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f p95v308b17.win32.zip
 
-  File32:         p95v308b15.win32.zip
+  File32:         p95v308b17.win32.zip
   ChecksumType32: sha256
   Checksum32:     B44CB82305FBCA3749E525C71E22C065B0CC683C213918FE44B5F383C4F16591
 


### PR DESCRIPTION
Filename format was no longer matching the regular expressions due to updates in the format - the number of digits had increased from 3 to 4.  Modified the regular expressions to accommodate and made additional updates to bring the updater into line with current standards.