### PR TITLE
(gh-546) Correct filename handling

### DIFF
--- a/automatic/vscode-maven/legal/VERIFICATION.txt
+++ b/automatic/vscode-maven/legal/VERIFICATION.txt
@@ -10,7 +10,7 @@ and can be verified by:
 
   https://marketplace.visualstudio.com/items?itemName=vscjava.maven
 
-and download the extension vscjava.vscode-maven-0.38.2022090603 using the Download Extension link
+and download the extension vscjava.vscode-maven-0.38.2022090603.vsix using the Download Extension link
 in the Resources section of the sidebar.
 
 Alternatively the package can be downloaded directly from
@@ -18,8 +18,8 @@ Alternatively the package can be downloaded directly from
   https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-maven/0.38.2022090603/vspackage
 
 2. The package can be validated by comparing checksums
-  - Use powershell function 'Get-Filehash' - Get-Filehash vscjava.vscode-maven-0.38.2022090603
-  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f vscjava.vscode-maven-0.38.2022090603
+  - Use powershell function 'Get-Filehash' - Get-Filehash vscjava.vscode-maven-0.38.2022090603.vsix
+  - Use chocolatey utility 'checksum.exe' - checksum -t sha256 -f vscjava.vscode-maven-0.38.2022090603.vsix
 
   Type:     sha256
   Checksum: E1E2CD90C6F7616D2F97DB93F06002B1781747EC4EBFA7A58803DC78B1CED912

--- a/automatic/vscode-maven/tools/chocolateyinstall.ps1
+++ b/automatic/vscode-maven/tools/chocolateyinstall.ps1
@@ -2,4 +2,4 @@
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-Install-VsCodeExtension -extensionId "$toolsDir\vscjava.vscode-maven-0.38.2022090603"
+Install-VsCodeExtension -extensionId "$toolsDir\vscjava.vscode-maven-0.38.2022090603.vsix"

--- a/automatic/vscode-maven/update.ps1
+++ b/automatic/vscode-maven/update.ps1
@@ -10,6 +10,19 @@ $reFileName32    = '(?<=\\|\s)(?<FileName>vscjava.+\.vsix)'
 $reVersion       = '(?<=\/)(?<Version>([\d]+\.[\d]+\.[\d]+\.?[\d]*))'
 $reVSCodeVersion = '(?<=(Visual Studio Code ))(?<Version>[0-9]+\.[0-9]+\.[0-9]+\.?[\d]*)(?=( or newer))'
 
+function global:au_BeforeUpdate {
+  mkdir tools -ea 0 | Out-Null
+  $toolsPath = Resolve-Path tools
+
+  Remove-Item -Force "$toolsPath\*.$Latest.FileType" -ea ignore
+
+  $outputFile = "{0}\{1}.{2}" -f $toolsPath, $Latest.FilenameBase, $Latest.FileType
+  Invoke-WebRequest -uri $Latest.Url32 -OutFile $outputFile
+
+  $global:Latest.Checksum32 = Get-FileHash $outputFile -Algorithm $Latest.ChecksumType32 | ForEach-Object Hash
+  $global:Latest.FileName32 = $outputFile
+}
+
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
@@ -22,32 +35,17 @@ function global:au_SearchReplace {
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "$($reFileName32)" = "$($Latest.FileNameBase)"
+      "$($reFileName32)" = "$($Latest.FileName32)"
     }
 
     ".\legal\VERIFICATION.txt"      = @{
       "$($reVersion)"    = "$($Latest.Version)"
-      "$($reFileName32)" = "$($Latest.FileNameBase)"
+      "$($reFileName32)" = "$($Latest.FileName32)"
       "$($reChecksum)"   = "$($Latest.Checksum32)"
     }
   }
 }
-function global:au_BeforeUpdate {
-  mkdir tools -ea 0 | Out-Null
-  $toolsPath = Resolve-Path tools
-
-  Write-Host 'Purging ' $Latest.FileType
-  Remove-Item -Force "$toolsPath\*.$Latest.FileType" -ea ignore
-
-  $outputFile = "{0}\{1}.{2}" -f $toolsPath, $Latest.FilenameBase, $Latest.FileType
-  Invoke-WebRequest -uri $Latest.Url32 -OutFile $outputFile
-
-  $global:Latest.Checksum32 = Get-FileHash $outputFile -Algorithm $Latest.ChecksumType32 | ForEach-Object Hash
-  $global:Latest.FileName32 = $outputFile
-}
-
 function global:au_GetLatest {
-  Write-Host('Running GetLatest')
   $extensionInfo = Get-VSMarketplaceExtensionDetails -Extension $extension -Publisher $publisher
 
   @{


### PR DESCRIPTION
The package was not updating as the filename for the vsix extension was not being matched by the regular expressions.  This was due to the base name (sans .vsix extension) being used in the update rather than the full filename - on subsequent runs the regular expression no longer matched on the filename.  Corrected the update to replace with the full filename.
