### PR TITLE
(gh-549) Correct package updates

### DIFF
--- a/automatic/vscode-pull-request-github/README.md
+++ b/automatic/vscode-pull-request-github/README.md
@@ -25,7 +25,7 @@ This extension allows you to review and manage [GitHub](https://github.com) pull
 
 ## Notes
 
-* This package requires Visual Studio Code 1.77.0-insider or newer.
+* This package requires Visual Studio Code 1.77.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
 * The extension will be installed in all editions of Visual Studio Code which can be found.
 * While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.

--- a/automatic/vscode-pull-request-github/vscode-pull-request-github.nuspec
+++ b/automatic/vscode-pull-request-github/vscode-pull-request-github.nuspec
@@ -39,7 +39,7 @@ This extension allows you to review and manage [GitHub](https://github.com) pull
 
 ## Notes
 
-* This package requires Visual Studio Code 1.77.0-insider or newer.
+* This package requires Visual Studio Code 1.77.0 or newer.
   You can install either the [vscode](https://chocolatey.org/packages/vscode) or [vscode-insiders](https://chocolatey.org/packages/vscode-insiders) package.
 * The extension will be installed in all editions of Visual Studio Code which can be found.
 * While this package installs a specific version of the extension, Visual Studio Code by default will update the extension to the latest version on startup if there's a newer version available on the marketplace.


### PR DESCRIPTION
Package was no longer updating due to a version update including `-insiders` that impacted the regular expression matching.  Manually reverted to standard versions to correct his and modified regular expression usage to bring the package into line with current standards.