### PR TITLE
(gh-555) Corrected coreinfo package update script

### DIFF
--- a/automatic/coreinfo/README.md
+++ b/automatic/coreinfo/README.md
@@ -1,9 +1,9 @@
-# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@024a0e31a291ceea63f7af5e63e2679403c5aa8f/icons/sysinternals.png" width="48" height="48" />Coreinfo - Windows Sysinternals](https://chocolatey.org/packages/coreinfo)
+# [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@f1075d8ebcef438242228bccd7320aff28f82ed0/icons/sysinternals.png" width="48" height="48" />Coreinfo - Windows Sysinternals](https://chocolatey.org/packages/coreinfo)
 
 [![Software License](https://img.shields.io/badge/License-Proprietary-grey.svg)](https://docs.microsoft.com/en-us/sysinternals/license-terms)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v3.53-blue)](https://docs.microsoft.com/sysinternals/downloads/coreinfo)
+[![Software version](https://img.shields.io/badge/Source-v3.6-blue)](https://docs.microsoft.com/sysinternals/downloads/coreinfo)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/coreinfo?label=Chocolatey)](https://chocolatey.org/packages/coreinfo)
 
 Coreinfo is a command-line utility that shows you the mapping between logical processors and the physical processor,

--- a/automatic/coreinfo/coreinfo.nuspec
+++ b/automatic/coreinfo/coreinfo.nuspec
@@ -3,13 +3,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>coreinfo</id>
-    <version>3.53</version>
+    <version>3.6</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/coreinfo</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Coreinfo - Windows Sysinternals</title>
     <authors>Mark Russinovich</authors>
     <projectUrl>https://docs.microsoft.com/sysinternals</projectUrl>
-    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@024a0e31a291ceea63f7af5e63e2679403c5aa8f/icons/sysinternals.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@f1075d8ebcef438242228bccd7320aff28f82ed0/icons/sysinternals.png</iconUrl>
     <copyright>Mark Russinovich</copyright>
     <licenseUrl>https://docs.microsoft.com/sysinternals/license-terms</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/automatic/coreinfo/tools/chocolateyInstall.ps1
+++ b/automatic/coreinfo/tools/chocolateyInstall.ps1
@@ -9,7 +9,7 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   url           = 'https://download.sysinternals.com/files/Coreinfo.zip'
-  checksum      = 'a35809a5364ab68444b2879491b4e742b302055279097dc83dbc0e0598242246'
+  checksum      = '969A77FD34F20D41BA6AF8DAC450BCA7EA39D47C2BBF431DBF4E14E77DDAB09C'
   checksumType  = 'sha256'
 }
 


### PR DESCRIPTION
The update script was no longer successfully detecting the available software version.  Modified the updater script to correct this and modified regular expression usage to be inline with current repository standards.