### PR TITLE
(gh-590) Handle correct file order on download page

### DIFF
--- a/automatic/ant/README.md
+++ b/automatic/ant/README.md
@@ -1,6 +1,6 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@170f8cefaff042f0fb37731acc25ce804e878d88/icons/ant.png" width="48" height="48" />Apache Ant](https://chocolatey.org/packages/ant)
 
-[![Software license](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://gitbox.apache.org/repos/asf?p=ant.git;a=blob;f=LICENSE)
+[![Software license](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://github.com/apache/ant/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
 [![Software version](https://img.shields.io/badge/Source-v1.10.14-blue.svg)](https://ant.apache.org/bindownload.cgi)

--- a/automatic/ant/ant.nuspec
+++ b/automatic/ant/ant.nuspec
@@ -10,10 +10,10 @@
     <authors>Apache</authors>
     <projectUrl>https://ant.apache.org</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@170f8cefaff042f0fb37731acc25ce804e878d88/icons/ant.png</iconUrl>
-    <copyright>Copyright 1999-2021 The Apache Software Foundation</copyright>
-    <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0.html</licenseUrl>
+    <copyright>Copyright 1999-2024 The Apache Software Foundation</copyright>
+    <licenseUrl>https://github.com/apache/ant/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://gitbox.apache.org/repos/asf/ant.git</projectSourceUrl>
+    <projectSourceUrl>https://github.com/apache/ant</projectSourceUrl>
     <docsUrl>https://ant.apache.org/manual/index.html</docsUrl>
     <mailingListUrl>http://ant.apache.org/mail.html</mailingListUrl>
     <bugTrackerUrl>http://issues.apache.org/bugzilla/buglist.cgi?product=Ant</bugTrackerUrl>

--- a/automatic/ant/legal/VERIFICATION.txt
+++ b/automatic/ant/legal/VERIFICATION.txt
@@ -8,13 +8,13 @@ be verified by:
 
 1. Go to the binary archive page
 
-  https://archive.apache.org/dist/ant/binaries/
+  https://downloads.apache.org/ant/binaries/
 
 and download the archive apache-ant-1.10.14-bin.zip using the links on the page.
 
 Alternatively the archive can be downloaded directly from
 
-  https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.zip
+  https://downloads.apache.org/ant/binaries/apache-ant-1.10.14-bin.zip
 
 2. The archive can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha512 apache-ant-1.10.14-bin.zip
@@ -25,4 +25,4 @@ Alternatively the archive can be downloaded directly from
   Type:     sha512
   Checksum: 6E85CF45726EE88C916976ABA07488B79DA84BE1A31B5C5441A65C28BB4436B5A5A373402C78AC6A3827BD261FB924124BB9534E52D6429162EAF57B9737124C
 
-Contents of file LICENSE.txt is obtained from https://gitbox.apache.org/repos/asf?p=ant.git;a=blob;f=LICENSE
+Contents of file LICENSE.txt is obtained from https://github.com/apache/ant/blob/master/LICENSE


### PR DESCRIPTION
Package was no longer updating as the order of files on the download page had been updated.  Corrected this and updated documentation links and regex handling.