### PR TITLE
(gh-592) Modify updater to retrieve from Github

### DIFF
--- a/automatic/bluej/README.md
+++ b/automatic/bluej/README.md
@@ -1,6 +1,6 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@ec1652f85e86682fba61efdbeb5a556dd6ad0284/icons/bluej.png" width="48" height="48"/>BlueJ - Beginners Java Development Environment](https://chocolatey.org/packages/bluej)
 
-[![Software license](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://www.bluej.org/about/LICENSE.txt)
+[![Software license](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/k-pet-group/BlueJ-Greenfoot/blob/main/LICENSE.txt)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
 [![Software version](https://img.shields.io/badge/Source-v5.4.1-blue.svg)](https://www.bluej.org/index.html)

--- a/automatic/bluej/bluej.nuspec
+++ b/automatic/bluej/bluej.nuspec
@@ -11,12 +11,12 @@
     <projectUrl>https://www.bluej.org</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@ec1652f85e86682fba61efdbeb5a556dd6ad0284/icons/bluej.png</iconUrl>
     <copyright>M. Kölling and J. Rosenberg</copyright>
-    <licenseUrl>https://www.bluej.org/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/k-pet-group/BlueJ-Greenfoot/blob/main/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/k-pet-group/BlueJ-Greenfoot</projectSourceUrl>
     <docsUrl>https://www.bluej.org/doc/documentation.html</docsUrl>
-    <mailingListUrl>https://blueroom.bluej.org/</mailingListUrl>
-    <bugTrackerUrl>https://gitlab.bluej.org/bluej/bjgf</bugTrackerUrl>
+    <mailingListUrl>https://bluej.org/faq.html</mailingListUrl>
+    <bugTrackerUrl>https://github.com/k-pet-group/BlueJ-Greenfoot/issues</bugTrackerUrl>
     <tags>bluej java ide</tags>
     <summary>Beginners Java development environment that allows you to develop Java programs quickly and easily</summary>
     <description><![CDATA[


### PR DESCRIPTION
Package was no longer updating following migration to Github. Updated to ensure correct handling and updated documentation links and regex handling.