### PR TITLE
(gh-592) Corrected regex matching for url and checksum

### DIFF
--- a/automatic/bluej/tools/chocolateyInstall.ps1
+++ b/automatic/bluej/tools/chocolateyInstall.ps1
@@ -7,8 +7,8 @@ if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
   FileType       = 'msi'
-  Url64Bit       = 'https://www.bluej.org/download/files/BlueJ-windows-541.msi'
-  Checksum64     = '950e9bfd2d5159432d96560a1c4645f221c9f85dfb930feed75f678bfdc904e0'
+  Url64Bit       = 'https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-5.4.2/BlueJ-windows-5.4.2.msi'
+  Checksum64     = '85fb8f701f705acac1d0a1920c53e851cb6595ce83de9d5e86b02194a63bb163'
   ChecksumType64 = 'sha256'
   SilentArgs     = '/quiet /qn /norestart'
   ValidExitCodes = @(0,3010)

--- a/automatic/bluej/update.ps1
+++ b/automatic/bluej/update.ps1
@@ -9,8 +9,8 @@ $user       = 'k-pet-group'
 $repository = 'BlueJ-Greenfoot'
 
 $reFilename64 = '(?<Filename64>Bluej-windows-.+\.msi)'
-$reChecksum64 = "(?<=Checksum64\s*=\s*)((?<Checksum64>([^'].+)))"
-$reUrl64      = "(?<=Url64Bit\s*=\s*)((?<Url64>([^'].+)))"
+$reChecksum64 = "(?<=Checksum64\s*=\s*')((?<Checksum64>([^'].+)))"
+$reUrl64      = "(?<=Url64Bit\s*=\s*')((?<Url64>([^'].+)))"
 $reVersion    = '(?<=[-|v])(?<Version>([\d]+\.[\d]+\.[\d]+))'
 function global:au_BeforeUpdate {
   $Latest.Checksum64 = Get-RemoteChecksum $Latest.Url64


### PR DESCRIPTION
The regex matching on the url and checksum was incorrect.    The
leading single quote was not included in the non-matching regular
expression  so the package args were being impacted on replacement.
Corrected the regex handling and updated to match the expected values
for the package version.