### PR TITLE
(gh-595) Modified updater to utilise Github common functions

### DIFF
--- a/automatic/dbgate.install/README.md
+++ b/automatic/dbgate.install/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/dbgate/dbgate)](https://github.com/dbgate/dbgate/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v5.3.4-blue)](https://github.com/mongodb/mongocli/releases/tag/v5.3.4)
+[![Software version](https://img.shields.io/badge/Source-v5.3.4-blue)](https://github.com/dbgate/dbgate/releases/tag/v5.3.4)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/dbgate.install?label=Chocolatey)](https://chocolatey.org/packages/dbgate.install)
 
 DbGate is cross-platform database manager. It's designed to be simple to use and effective, when working

--- a/automatic/dbgate.install/update.ps1
+++ b/automatic/dbgate.install/update.ps1
@@ -3,9 +3,10 @@
 $ErrorActionPreference = 'STOP'
 
 function global:au_BeforeUpdate {
-  $Latest.FileName64 = "$($Latest.FileName64Install)"
   $Latest.Url64      = "$($Latest.Url64Install)"
-
+  $Latest.FileName64 = "$($Latest.FileName64Install)"
+  $Latest.FileType   = 'exe'
+  
   Get-RemoteFiles -Purge -NoSuffix
 }
 
@@ -21,10 +22,10 @@ function global:au_SearchReplace {
       "$($reVersion)"  = "$($Latest.Version)"
     }
 
-    ".\tools\chocolateyinstall.ps1" = @{
+    ".\tools\chocolateyInstall.ps1" = @{
       "$($reInstall)" = "$($Latest.FileName64)"
     }
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoCheckUrl -NoReadme

--- a/automatic/dbgate.portable/README.md
+++ b/automatic/dbgate.portable/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/dbgate/dbgate)](https://github.com/dbgate/dbgate/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v5.3.4-blue)](https://github.com/mongodb/mongocli/releases/tag/v5.3.4)
+[![Software version](https://img.shields.io/badge/Source-v5.3.4-blue)](https://github.com/dbgate/dbgate/releases/tag/v5.3.4)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/dbgate.portable?label=Chocolatey)](https://chocolatey.org/packages/dbgate.portable)
 
 DbGate is cross-platform database manager. It's designed to be simple to use and effective, when working

--- a/automatic/dbgate.portable/update.ps1
+++ b/automatic/dbgate.portable/update.ps1
@@ -3,8 +3,8 @@
 $ErrorActionPreference = 'STOP'
 
 function global:au_BeforeUpdate {
-  $Latest.FileName64 = "$($Latest.FileName64Portable)"
   $Latest.Url64      = "$($Latest.Url64Portable)"
+  $Latest.FileName64 = "$($Latest.FileName64Portable)"
   $Latest.FileType   = 'zip'
 
   Get-RemoteFiles -Purge -NoSuffix
@@ -22,10 +22,10 @@ function global:au_SearchReplace {
       "$($reVersion)"  = "$($Latest.Version)"
     }
 
-    ".\tools\chocolateyinstall.ps1" = @{
+    ".\tools\chocolateyInstall.ps1" = @{
       "$($rePortable)" = "$($Latest.FileName64)"
     }
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoCheckUrl -NoReadme

--- a/automatic/dbgate/README.md
+++ b/automatic/dbgate/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/dbgate/dbgate)](https://github.com/dbgate/dbgate/blob/master/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v5.3.4-blue)](https://github.com/mongodb/mongocli/releases/tag/v5.3.4)
+[![Software version](https://img.shields.io/badge/Source-v5.3.4-blue)](https://github.com/dbgate/dbgate/releases/tag/v5.3.4)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/dbgate?label=Chocolatey)](https://chocolatey.org/packages/dbgate)
 
 DbGate is cross-platform database manager. It's designed to be simple to use and effective, when working

--- a/automatic/dbgate/update.ps1
+++ b/automatic/dbgate/update.ps1
@@ -1,14 +1,17 @@
 ﻿import-module au
 
+Import-Module ..\..\scripts\chocolatey-helpers\Chocolatey-Helpers.psd1
+
 $ErrorActionPreference = 'STOP'
 
-$domain   = 'https://github.com'
-$releases = "${domain}/dbgate/dbgate/releases/latest"
+$domain     = 'https://github.com'
+$user       = 'dbgate'
+$repository = 'dbgate'
 
-$reChecksum     = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
-$reInstall      = "(?<=\d\/|\s|')(?<Filename>(dbgate.+win_x64\.exe))"
-$rePortable     = "(?<=\d\/|\s|')(?<Filename>(dbgate.+win_x64\.zip))"
-$reVersion      = '(?<=v|\[)(?<Version>([\d]+\.[\d]+\.[\d]+\.?[\d]*))'
+$reChecksum = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
+$reInstall  = "(?<=\d\/|\s|')(?<FileName64Install>(dbgate-\d\.\d\.\d-win_x64\.exe))"
+$rePortable = "(?<=\d\/|\s|')(?<FileName64Portable>(dbgate-\d\.\d\.\d-win_x64\.zip))"
+$reVersion  = '(?<=v|\[)(?<Version>([\d]+\.[\d]+\.[\d]+\.?[\d]*))'
 
 function global:au_BeforeUpdate {
 }
@@ -26,19 +29,15 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
-  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
-  $assetsUri    = "{0}/expanded_assets/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
-  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
+  $downloadPage = Get-GitHubLatestReleasePage -User $user -Repository $repository
 
+  $url64Install      = $downloadPage.links | Where-Object href -match $reInstall | Select-Object -first 1 -expand href | ForEach-Object { $domain + $_ }
+  $fileName64Install = $Matches.FileName64Install
 
-  $url64Install      = $assetsPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
-  $fileName64Install = $url64Install -split '/' | select-object -last 1
+  $url64Portable      = $downloadPage.links | Where-Object href -match $rePortable | Select-Object -first 1 -expand href | ForEach-Object { $domain + $_ }
+  $fileName64Portable = $Matches.FileName64Portable
 
-  $url64Portable      = $assetsPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
-  $fileName64Portable = $url64Portable -split '/' | select-object -last 1
-
-  $version = $url64Portable -match $reVersion | foreach-object { $Matches.Version }
+  $version = $url64Portable -match $reVersion | ForEach-Object { $Matches.Version }
 
   return @{
     Url64Install       = $url64Install
@@ -50,5 +49,5 @@ function global:au_GetLatest {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-  update -ChecksumFor none -NoReadme
+  update -ChecksumFor none -NoCheckUrl -NoReadme
 }


### PR DESCRIPTION
Package updates were not functioning due to the Github API changes. Modified the updater to use the common functions to address this, and corrected references in README.md to link to the dbgate package rather than mongodb.