### PR TITLE
(gh-598) Added module import for common helper functions

### DIFF
--- a/automatic/naps2/update.ps1
+++ b/automatic/naps2/update.ps1
@@ -1,5 +1,7 @@
 ﻿import-module au
 
+Import-Module ..\..\scripts\chocolatey-helpers\Chocolatey-Helpers.psd1
+
 $ErrorActionPreference = 'STOP'
 
 $domain     = 'https://github.com'


### PR DESCRIPTION
The update script was not functioning in the build environment due to the absence of the appropriate module.  Updated to import the module containing the helper functions.