### PR TITLE
(gh-602) Added support for universal archive

### DIFF
--- a/automatic/dotcover-cli/README.md
+++ b/automatic/dotcover-cli/README.md
@@ -15,6 +15,7 @@ Tools can be integrated with a Continuous Integration server.
 ## Notes
 
 * Related package: [dotcover](https://chocolatey.org/packages/dotCover)
-* The 64-bit version of the pacakge supports generatinv coverage for both 32 and 64-bit applications.
+* The 64-bit version of the pacakge supports generating coverage for both 32 and 64-bit applications.
+* The package installs a universal archive which contains the 32-bit and 64-bit versions of the tools.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.

--- a/automatic/dotcover-cli/legal/VERIFICATION.txt
+++ b/automatic/dotcover-cli/legal/VERIFICATION.txt
@@ -8,31 +8,22 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://www.jetbrains.com/dotcover/download/other.html
+  https://www.jetbrains.com/dotcover/download/#section=commandline
 
-and download the archive JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip or
-JetBrains.dotCover.CommandLineTools.windows-x64.2024.3.7.zip using the relevant links.
+and download the archive JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip
+using the download button.
 
 Alternatively the installer can be downloaded directly from
 
-https://download.jetbrains.com/resharper/dotUltimate.2024.3.7/JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip
-https://download.jetbrains.com/resharper/dotUltimate.2024.3.7/JetBrains.dotCover.CommandLineTools.windows-x64.2024.3.7.zip
+  https://download.jetbrains.com/resharper/dotUltimate.2024.3.7/JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip
 
 2. The archives can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip
   - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip
   - Download the checksums from https://download.jetbrains.com/resharper/dotUltimate.2024.3.7/JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip.sha256
 
-  File32:         JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip
-  ChecksupType32: sha256
-  Checksum32:     DE35CB48A8924DAC6DD3E7EF54FA7014BA4920B0DAB0476D36D0733EEF68951F
-
-  - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 JetBrains.dotCover.CommandLineTools.windows-x64.2024.3.7.zip
-  - Use chocolatey utility 'checksum.exe'  - checksum -t sha256 -f JetBrains.dotCover.CommandLineTools.windows-x64.2024.3.7.zip
-  - Download the checksums from https://download.jetbrains.com/resharper/dotUltimate.2024.3.7/JetBrains.dotCover.CommandLineTools.windows-x64.2024.3.7.zip.sha256
-
-  File64:         JetBrains.dotCover.CommandLineTools.windows-x64.2024.3.7.zip
-  ChecksupType64: sha256
-  Checksum64:     2F9FC79BD94FB06E6E626A257E9C9BB1609AC314691B71BC05D771AA13E71FA9
+  File:         JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip
+  ChecksupType: sha256
+  Checksum:     DE35CB48A8924DAC6DD3E7EF54FA7014BA4920B0DAB0476D36D0733EEF68951F
 
 Contents of file LICENSE.txt is obtained from https://www.jetbrains.com/legal/agreements/user.html

--- a/automatic/dotcover-cli/tools/chocolateyInstall.ps1
+++ b/automatic/dotcover-cli/tools/chocolateyInstall.ps1
@@ -2,22 +2,25 @@
 
 $toolsDir  = Split-Path -parent $MyInvocation.MyCommand.Definition
 
-$archive32 = Join-Path $toolsDir 'JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip'
-$archive64 = Join-Path $toolsDir 'JetBrains.dotCover.CommandLineTools.windows-x64.2024.3.7.zip'
-
-if ((Get-ProcessorBits 32) -or $env:ChocolateyForceX86 -eq 'true') {
-  $archive = $archive32
-} else {
-  $archive = $archive64
-}
+$archive = Join-Path $toolsDir 'JetBrains.dotCover.CommandLineTools.windows-x86.2024.3.7.zip'
 
 $unzipArgs = @{
   PackageName  = $env:ChocolateyPackageName
   FileFullPath = $archive
   Destination  = $toolsDir
+  Checksum     = 'de35cb48a8924dac6dd3e7ef54fa7014ba4920b0dab0476d36d0733eef68951f'
+  ChecksumType = 'sha256'
 }
 
 Get-ChocolateyUnzip @unzipArgs
 
-Remove-Item $toolsDir\*.zip -ea 0
+$unzipArgs = @{
+  PackageName  = $env:ChocolateyPackageName
+  FileFullPath = $archive -replace '\.(zip|gz)$', ''
+  Destination  = $toolsDir
+}
+
+Get-ChocolateyUnzip @unzipArgs
+
+Remove-Item "$toolsDir\*.{zip,tar,gz}" -ea 0
 Get-ChildItem $toolsDir -include *.exe -exclude 'dotCover.exe' -recurse  | Select-Object { New-Item "$_.ignore" -type file -force } | Out-Null

--- a/automatic/dotcover-cli/update.ps1
+++ b/automatic/dotcover-cli/update.ps1
@@ -5,15 +5,11 @@ $ErrorActionPreference = 'STOP'
 $domain   = 'https://data.services.jetbrains.com'
 $releases = "${domain}/products?code=DCCLT&release.type=release"
 
-$reFile32        = '(?<![\/\.])(?<FileName32>Jet.+x86.+zip)'
-$reFile64        = '(?<![\/\.])(?<FileName64>Jet.+x64.+zip)'
-$reChecksum32    = '(?<=Checksum32:\s*)(?<Checksum32>[^\s]+)'
-$reChecksum64    = '(?<=Checksum64:\s*)(?<Checksum64>[^\s]+)'
-$reChecksum32Url = '(?<Checksum32Url>https.+x86.+256)'
-$reChecksum64Url = '(?<Checksum64Url>https.+x64.+256)'
-$reUrl32         = '(?<Url32>https.+x86.+zip)'
-$reUrl64         = '(?<Url64>https.+x64.+zip)'
-$reVersion       = '(?<=v)(?<Version>\d+\.\d[\.\d]*)'
+$reFile        = '(?<![\/\.])(?<FileName>Jet.+[zip|gz])'
+$reChecksum    = "(?<=Checksum\s*[:=]\s*'?)(?<Checksum>[^\s|^']+)"
+$reChecksumUrl = '(?<ChecksumUrl>https.+256)'
+$reUrl         = '(?<Url>https.+?\.(zip|gz)$)'
+$reVersion     = '(?<=v)(?<Version>\d+\.\d+[\.\d]*)'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -26,45 +22,35 @@ function global:au_SearchReplace {
     }
 
     ".\legal\VERIFICATION.txt" = @{
-      "$($reFile32)"        = "$($Latest.FileName32)"
-      "$($reUrl32)"         = "$($Latest.Url32)"
-      "$($reChecksum32)"    = "$($Latest.Checksum32)"
-      "$($reChecksum32Url)" = "$($Latest.Checksum32Url)"
-      "$($reFile64)"        = "$($Latest.FileName64)"
-      "$($reUrl64)"         = "$($Latest.Url64)"
-      "$($reChecksum64)"    = "$($Latest.Checksum64)"
-      "$($reChecksum64Url)" = "$($Latest.Checksum64Url)"
+      "$($reFile)"        = "$($Latest.FileName32)"
+      "$($reUrl)"         = "$($Latest.Url32)"
+      "$($reChecksum)"    = "$($Latest.Checksum32)"
+      "$($reChecksumUrl)" = "$($Latest.Checksum32Url)"
     }
 
     ".\tools\chocolateyInstall.ps1" = @{
-      "$($reFile32)" = "$($Latest.FileName32)"
-      "$($reFile64)" = "$($Latest.FileName64)"
+      "$($reFile)"     = "$($Latest.FileName32)"
+      "$($reChecksum)" = "$($Latest.Checksum32)"
     }
   }
 }
 
 function global:au_GetLatest {
-  $json = Invoke-RestMethod -Uri $releases
+  $packageData = Invoke-RestMethod -Uri $releases
 
-  $release = $json[0].releases[0]
+  $release = $packageData.releases[0]
 
-  $url32         = $release.downloads.windows32.link
-  $fileName32    = $url32 -split '/' | Select-Object -Last 1
-  $checksum32Url = $release.downloads.windows32.checksumLink
-  $url64         = $release.downloads.windows64.link
-  $fileName64    = $url64 -split '/' | Select-Object -Last 1
-  $checksum64Url = $release.downloads.windows64.checksumLink
-  $version       = $release.version
+  $url         = $release.downloads.'cross-platform'.link
+  $fileName    = $url -split '/' | Select-Object -Last 1
+  $checksumUrl = $release.downloads.'cross-platform'.checksumLink
+  $version     = $release.version
 
   return @{
-    FileName32    = $fileName32
-    Url32         = $url32
-    Checksum32Url = $checksum32Url
-    FileName64    = $fileName64
-    Url64         = $url64
-    Checksum64Url = $checksum64Url
+    FileName32    = $fileName
+    Url32         = $url
+    Checksum32Url = $checksumUrl
     Version       = $version
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoCheckUrl -NoReadme


### PR DESCRIPTION
Automatic updates for  the package were failing due to a change in the distribution structure - rather than platform-specifc packages the package, as of version 2005.1, is not ditributed as a universal archive.
Modified the documentation along with the package updater and installation to reflect this.