### PR TITLE
(gh-606) Updated package publisher details

### DIFF
--- a/automatic/vscode-spring-boot/README.md
+++ b/automatic/vscode-spring-boot/README.md
@@ -1,9 +1,9 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0bf6a976385899a2fff0d6c1adb822da42a08d10/icons/vscode-spring-boot.png" width="48" height="48" />Spring Boot Tools VSCode Extension](<https://chocolatey.org/packages/vscode-spring-boot>)
 
-[![Software license](https://img.shields.io/badge/license-EPL--1.0-red)](https://github.com/spring-projects/sts4/blob/master/license.txt)
+[![Software license](https://img.shields.io/badge/license-EPL--1.0-red)](https://marketplace.visualstudio.com/items/vmware.vscode-spring-boot/license)
 [![Maintenance status](https://img.shields.io/badge/maintained-yes-green.svg)](https://github.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Visual Studio Marketplace version](https://img.shields.io/visual-studio-marketplace/v/Pivotal.vscode-spring-boot?label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-spring-boot)
+[![Visual Studio Marketplace version](https://img.shields.io/visual-studio-marketplace/v/vmware.vscode-spring-boot?label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=vmware.vscode-spring-boot)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/vscode-spring-boot?label=Chocolatey)](https://chocolatey.org/packages/vscode-spring-boot)
 
 VSCode extension and Language Server providing support for working with Spring Boot `application.properties`, `application.yml` and `.java` files.

--- a/automatic/vscode-spring-boot/legal/VERIFICATION.txt
+++ b/automatic/vscode-spring-boot/legal/VERIFICATION.txt
@@ -8,14 +8,13 @@ and can be verified by:
 
 1. Go to the Visual Studio Marketplace page for the extension
 
-   https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-spring-boot
+   https://marketplace.visualstudio.com/items?itemName=vmware.vscode-spring-boot
 
-and download the extension Pivotal.vscode-spring-boot-1.31.0.vsix using the Download Extension link
+and download the extension vmware.vscode-spring-boot-1.31.0.vsix using the Download Extension link
 in the Resources section of the sidebar.
 
 Alternatively the package can be downloaded directly from
-
-  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/Pivotal/vsextensions/vscode-spring-boot/1.31.0/vspackage
+  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vmware/vsextensions/vscode-spring-boot/1.31.0/vspackage
 
 2. The extension can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash Pivotal.vscode-spring-boot-1.31.0.vsix
@@ -24,4 +23,4 @@ Alternatively the package can be downloaded directly from
   Type:     sha256
   Checksum: 837BF7E2D8D4697084C26AE3CCD925F100B78F59B7EE1849D163EC5EDC65D4A1
 
-  Contents of LICENSE.txt is obtained from https://github.com/spring-projects/sts4/blob/master/license.txt
+  Contents of LICENSE.txt is obtained from https://marketplace.visualstudio.com/items/vmware.vscode-spring-boot/license

--- a/automatic/vscode-spring-boot/tools/chocolateyinstall.ps1
+++ b/automatic/vscode-spring-boot/tools/chocolateyinstall.ps1
@@ -2,4 +2,4 @@
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-Install-VsCodeExtension -extensionId "$toolsDir\Pivotal.vscode-spring-boot-1.31.0.vsix"
+Install-VsCodeExtension -extensionId "$toolsDir\vmware.vscode-spring-boot-1.31.0.vsix"

--- a/automatic/vscode-spring-boot/tools/chocolateyuninstall.ps1
+++ b/automatic/vscode-spring-boot/tools/chocolateyuninstall.ps1
@@ -1,3 +1,3 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-Uninstall-VsCodeExtension -extensionId 'Pivotal.vscode-spring-boot'
+Uninstall-VsCodeExtension -extensionId 'vmware.vscode-spring-boot'

--- a/automatic/vscode-spring-boot/update.ps1
+++ b/automatic/vscode-spring-boot/update.ps1
@@ -4,26 +4,31 @@ Import-Module ..\..\scripts\vs-marketplace\VS-Marketplace.psd1
 $ErrorActionPreference = 'Stop'
 
 $extension = 'vscode-spring-boot'
-$publisher = 'Pivotal'
+$publisher = 'vmware'
+
+$reChecksum      = '(?<=Checksum:\s+)(?<Checksum>[^\s]*)'
+$reCopyright     = '(?<=copyright>)(?<Copyright>.*)(?=<\/copyright>)'
+$reVsCodeVersion = '(?<=Code\s>=)(?<Version>\d+(\.*\d*)*)'
+$reVersion       = '(?<Version>\d+\.\d*\.\d*)'
 
 function global:au_SearchReplace {
   @{
     "$($Latest.PackageName).nuspec" = @{
-      "(copyright>)(.*)(<\/copyright>)"                          = "`${1}$($Latest.Copyright)`${3}"
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "$($reCopyright)"     = "$($Latest.Copyright)"
+      "$($reVsCodeVersion)" = "$($Latest.VSCodeVersion)"
     }
 
     ".\README.md" = @{
-      "(Visual Studio Code )([0-9]+\.[0-9]+\.[0-9]+)( or newer)" = "`${1}$($Latest.VSCodeVersion)`${3}"
+      "$($reVsCodeVersion)" = "$($Latest.VSCodeVersion)"
     }
 
     ".\tools\chocolateyinstall.ps1" = @{
-      "([0-9]+\.[0-9]+\.[0-9]+)" = "$($Latest.Version)"
+      "$($reVersion)" = "$($Latest.Version)"
     }
 
     ".\legal\VERIFICATION.txt"      = @{
-      "([0-9]+\.[0-9]+\.[0-9]+)" = "$($Latest.Version)"
-      "(Checksum:\s*)(.*)"       = "`${1}$($Latest.Checksum32)"
+      "$($reVersion)"  = "$($Latest.Version)"
+      "$($reChecksum)" = "$($Latest.Checksum32)"
     }
   }
 }

--- a/automatic/vscode-spring-boot/vscode-spring-boot.nuspec
+++ b/automatic/vscode-spring-boot/vscode-spring-boot.nuspec
@@ -7,18 +7,21 @@
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/vscode-spring-boot</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Spring Boot Tools VSCode Extension</title>
-    <authors>Pivotal</authors>
-    <projectUrl>https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-spring-boot</projectUrl>
+    <authors>VMWare</authors>
+    <projectUrl>https://spring.io/tools</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0bf6a976385899a2fff0d6c1adb822da42a08d10/icons/vscode-spring-boot.png</iconUrl>
-    <copyright>Copyright 2018-2022 Pivotal</copyright>
-    <licenseUrl>https://marketplace.visualstudio.com/items/Pivotal.vscode-spring-boot/license</licenseUrl>
+    <copyright>Copyright 2018-2022 vmware</copyright>
+    <licenseUrl>https://marketplace.visualstudio.com/items/vmware.vscode-spring-boot/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/spring-projects/sts4</projectSourceUrl>
-    <docsUrl>https://github.com/spring-projects/sts4/wiki</docsUrl>
-    <bugTrackerUrl>https://github.com/spring-projects/sts4/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/spring-projects/spring-tools</projectSourceUrl>
+    <docsUrl>https://github.com/spring-projects/spring-tools/wiki</docsUrl>
+    <mailingListUrl>https://stackoverflow.com/questions/tagged/spring-tools</mailingListUrl>
+    <bugTrackerUrl>https://github.com/spring-projects/spring-tools/issues</bugTrackerUrl>
     <tags>spring-boot java java-properties application-properties application-yaml vscode pivotal</tags>
     <summary>VS Code Language Server for Spring Boot</summary>
-    <description><![CDATA[VSCode extension and Language Server providing support for working with Spring Boot `application.properties`, `application.yml` and `.java` files.
+    <description><![CDATA[
+VSCode extension and Language Server providing support for working with Spring Boot
+`application.properties`, `application.yml` and `.java` files.
 
 ## Features
 
@@ -42,8 +45,9 @@
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]></description>
-    <releaseNotes>https://marketplace.visualstudio.com/items/Pivotal.vscode-spring-boot/changelog</releaseNotes>
+    <releaseNotes>https://marketplace.visualstudio.com/items/vmware.vscode-spring-boot/changelog</releaseNotes>
     <dependencies>
+      <dependency id="vscode-java"  />
       <dependency id="chocolatey-vscode.extension" version="1.1.0" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
The publisher for the package had changed from Pivotal to VMWare so the package was no longer updating.  Modified the package publisher and docuemtnation to reflect the new publisher.