### PR TITLE
(gh-585) Updated package to reflect migration new repository

### DIFF
--- a/automatic/mongodb-cli.install/README.md
+++ b/automatic/mongodb-cli.install/README.md
@@ -1,15 +1,13 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0be6f44308aeb981f08bca54c9e9a38ed158a326/icons/mongodb-cli.png" width="48" height="48" />MongoDB Command Line Interface (Install)](https://chocolatey.org/packages/mongodb-cli.install)
 
-[![GitHub license](https://img.shields.io/github/license/mongodb/mongocli)](https://github.com/mongodb/mongocli/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/mongodb/mongodb-cli)](https://github.com/mongodb/mongodb-cli/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v2.0.3-blue)](https://github.com/mongodb/mongocli/releases/tag/v2.0.3)
+[![Software version](https://img.shields.io/badge/Source-v2.0.3-blue)](https://github.com/mongodb/mongodb-cli/releases/tag/mongocli/v2.0.3)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/mongodb-cli.install?label=Chocolatey)](https://chocolatey.org/packages/mongodb-cli.install)
 
-Create and manage MongoDB Cloud resources from your command line and easily automate them using scripts
-
-The MongoDB CLI is the most seamless way to create and manage MongoDB Cloud resources. Spin up new database
-environments, create users, manage network access, and much more, all while avoiding repetitive tasks.
+The MongoDB CLI is a modern command line interface that enables you to manage your MongoDB services
+from the terminal.  Test, script, and execute other actions — all from one tool.
 
 ## Features
 

--- a/automatic/mongodb-cli.install/legal/VERIFICATION.txt
+++ b/automatic/mongodb-cli.install/legal/VERIFICATION.txt
@@ -8,14 +8,14 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/mongodb/mongocli/releases/tag/v2.0.3
+  https://github.com/mongodb/mongodb-cli/releases/tag/mongocli/v2.0.3
 
 and download the archive mongocli_2.0.3_windows_x86_64.msi using the links in the relevant
 asset section of the page.
 
 Alternatively the build can be downloaded directly from
 
-  https://github.com/mongodb/mongocli/releases/download/v2.0.3/mongocli_2.0.3_windows_x86_64.msi
+  https://github.com/mongodb/mongodb-cli/releases/download/mongocli/v2.0.3/mongocli_2.0.3_windows_x86_64.msi
 
 2. The archive can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 mongocli_2.0.3_windows_x86_64.msi

--- a/automatic/mongodb-cli.install/mongodb-cli.install.nuspec
+++ b/automatic/mongodb-cli.install/mongodb-cli.install.nuspec
@@ -4,31 +4,29 @@
   <metadata>
     <id>mongodb-cli.install</id>
     <version>2.0.3</version>
-    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/mongodb-cli.install</packageSourceUrl>
+    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/mongodb-cli</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>MongoDB Command Line Interface (Install)</title>
     <authors>MongoDB</authors>
-    <projectUrl>https://www.mongodb.com/cloud/cli</projectUrl>
+    <projectUrl>https://github.com/mongodb/mongodb-cli</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0be6f44308aeb981f08bca54c9e9a38ed158a326/icons/mongodb-cli.png</iconUrl>
     <copyright>Copyright MongoDB Inc</copyright>
-    <licenseUrl>https://github.com/mongodb/mongocli/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/mongodb/mongodb-cli/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/mongodb/mongocli</projectSourceUrl>
+    <projectSourceUrl>https://github.com/mongodb/mongodb-cli</projectSourceUrl>
     <docsUrl>https://www.mongodb.com/docs/mongocli/v2.0</docsUrl>
-    <bugTrackerUrl>https://github.com/mongodb/mongocli/issues</bugTrackerUrl>
-    <tags>mongodb mongocli cli mongodb-atlas mongodb-cloud-manager mongodb-ops-manager</tags>
-    <summary>Manage your MongoDB in the cloud</summary>
+    <bugTrackerUrl>https://github.com/mongodb/mongodb-cli/issues</bugTrackerUrl>
+    <tags>mongodb mongocli cli mongodb-cloud-manager mongodb-ops-manager</tags>
+    <summary>MongoDB CLI for Cloud Manager and Ops Manager</summary>
     <description><![CDATA[
 
-Create and manage MongoDB Cloud resources from your command line and easily automate them using scripts
-
-The MongoDB CLI is the most seamless way to create and manage MongoDB Cloud resources. Spin up new database
-environments, create users, manage network access, and much more, all while avoiding repetitive tasks.
+The MongoDB CLI is a modern command line interface that enables you to manage your MongoDB services
+from the terminal.  Test, script, and execute other actions — all from one tool.
 
 ## Features
 
-* **Unified control plane** Manage MongoDB Cloud services from MongoDB Atlas and Atlas Data Lake to management platforms
-such as MongoDB Ops Manager
+* **Simple commands** Use simple, one-line commands to interact with MongoDB Cloud Manager or Ops Manager, and
+to automate management tasks for your deployments
 
 * **Organize your resources** Create organizations and projects within your MongoDB Cloud account to easily isolate
 resources and manage access by team
@@ -41,14 +39,12 @@ commands and syntax
 ## Notes
 
 * MongoDB CLI is only provided in a 64-bit version
-* The package installer deploys the executables to the `[Environment]::GetFolderPath("ProgramFilesX86")` folder
-(ie. the system install location for 32-bit applications) even though the binary is 64-bit
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
 If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.
 
 ]]>
     </description>
-    <releaseNotes>https://www.mongodb.com/docs/mongocli/v2.0/release-notes</releaseNotes>
+    <releaseNotes>https://www.mongodb.com/docs/mongocli/current/release-notes</releaseNotes>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/mongodb-cli.portable/README.md
+++ b/automatic/mongodb-cli.portable/README.md
@@ -1,15 +1,13 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0be6f44308aeb981f08bca54c9e9a38ed158a326/icons/mongodb-cli.png" width="48" height="48" />MongoDB Command Line Interface (Portable)](https://chocolatey.org/packages/mongodb-cli.portable)
 
-[![GitHub license](https://img.shields.io/github/license/mongodb/mongocli)](https://github.com/mongodb/mongocli/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/mongodb/mongodb-cli)](https://github.com/mongodb/mongodb-cli/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v2.0.3-blue)](https://github.com/mongodb/mongocli/releases/tag/v2.0.3)
+[![Software version](https://img.shields.io/badge/Source-v2.0.3-blue)](https://github.com/mongodb/mongodb-cli/releases/tag/mongocli/v2.0.3)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/mongodb-cli.portable?label=Chocolatey)](https://chocolatey.org/packages/mongodb-cli.portable)
 
-Create and manage MongoDB Cloud resources from your command line and easily automate them using scripts
-
-The MongoDB CLI is the most seamless way to create and manage MongoDB Cloud resources. Spin up new database
-environments, create users, manage network access, and much more, all while avoiding repetitive tasks.
+The MongoDB CLI is a modern command line interface that enables you to manage your MongoDB services
+from the terminal.  Test, script, and execute other actions — all from one tool.
 
 ## Features
 

--- a/automatic/mongodb-cli.portable/legal/VERIFICATION.txt
+++ b/automatic/mongodb-cli.portable/legal/VERIFICATION.txt
@@ -8,14 +8,14 @@ be verified by:
 
 1. Go to the binary distribution page
 
-  https://github.com/mongodb/mongocli/releases/tag/v2.0.3
+  https://github.com/mongodb/mongodb-cli/releases/tag/mongocli/v2.0.3
 
 and download the archive mongocli_2.0.3_windows_x86_64.zip using the links in the relevant
 asset section of the page.
 
 Alternatively the build can be downloaded directly from
 
-  https://github.com/mongodb/mongocli/releases/download/v2.0.3/mongocli_2.0.3_windows_x86_64.zip
+  https://github.com/mongodb/mongodb-cli/releases/download/mongocli/v2.0.3/mongocli_2.0.3_windows_x86_64.zip
 
 2. The archive can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash -Algorithm sha256 mongocli_2.0.3_windows_x86_64.zip

--- a/automatic/mongodb-cli.portable/mongodb-cli.portable.nuspec
+++ b/automatic/mongodb-cli.portable/mongodb-cli.portable.nuspec
@@ -4,31 +4,29 @@
   <metadata>
     <id>mongodb-cli.portable</id>
     <version>2.0.3</version>
-    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/mongodb-cli.portable</packageSourceUrl>
+    <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/mongodb-cli</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>MongoDB Command Line Interface (Portable)</title>
     <authors>MongoDB</authors>
-    <projectUrl>https://www.mongodb.com/cloud/cli</projectUrl>
+    <projectUrl>https://github.com/mongodb/mongodb-cli</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0be6f44308aeb981f08bca54c9e9a38ed158a326/icons/mongodb-cli.png</iconUrl>
     <copyright>Copyright MongoDB Inc</copyright>
-    <licenseUrl>https://github.com/mongodb/mongocli/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/mongodb/mongodb-cli/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/mongodb/mongocli</projectSourceUrl>
+    <projectSourceUrl>https://github.com/mongodb/mongodb-cli</projectSourceUrl>
     <docsUrl>https://www.mongodb.com/docs/mongocli/v2.0</docsUrl>
-    <bugTrackerUrl>https://github.com/mongodb/mongocli/issues</bugTrackerUrl>
-    <tags>mongodb mongocli cli mongodb-atlas mongodb-cloud-manager mongodb-ops-manager</tags>
-    <summary>Manage your MongoDB in the cloud</summary>
+    <bugTrackerUrl>https://github.com/mongodb/mongodb-cli/issues</bugTrackerUrl>
+    <tags>mongodb mongocli cli mongodb-cloud-manager mongodb-ops-manager</tags>
+    <summary>MongoDB CLI for Cloud Manager and Ops Manager</summary>
     <description><![CDATA[
 
-Create and manage MongoDB Cloud resources from your command line and easily automate them using scripts
-
-The MongoDB CLI is the most seamless way to create and manage MongoDB Cloud resources. Spin up new database
-environments, create users, manage network access, and much more, all while avoiding repetitive tasks.
+The MongoDB CLI is a modern command line interface that enables you to manage your MongoDB services
+from the terminal.  Test, script, and execute other actions — all from one tool.
 
 ## Features
 
-* **Unified control plane** Manage MongoDB Cloud services from MongoDB Atlas and Atlas Data Lake to management platforms
-such as MongoDB Ops Manager
+* **Simple commands** Use simple, one-line commands to interact with MongoDB Cloud Manager or Ops Manager, and
+to automate management tasks for your deployments
 
 * **Organize your resources** Create organizations and projects within your MongoDB Cloud account to easily isolate
 resources and manage access by team
@@ -46,7 +44,7 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://www.mongodb.com/docs/mongocli/v2.0/release-notes</releaseNotes>
+    <releaseNotes>https://www.mongodb.com/docs/mongocli/current/release-notes</releaseNotes>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/mongodb-cli/README.md
+++ b/automatic/mongodb-cli/README.md
@@ -1,15 +1,13 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0be6f44308aeb981f08bca54c9e9a38ed158a326/icons/mongodb-cli.png" width="48" height="48" />MongoDB Command Line Interface (mongocli)](https://chocolatey.org/packages/mongodb-cli)
 
-[![GitHub license](https://img.shields.io/github/license/mongodb/mongocli)](https://github.com/mongodb/mongocli/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/mongodb/mongodb-cli)](https://github.com/mongodb/mongodb-cli/blob/main/LICENSE)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v2.0.3-blue)](https://github.com/mongodb/mongocli/releases/tag/v2.0.3)
+[![Software version](https://img.shields.io/badge/Source-v2.0.3-blue)](https://github.com/mongodb/mongodb-cli/releases/tag/mongocli/v2.0.3)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/mongodb-cli?label=Chocolatey)](https://chocolatey.org/packages/mongodb-cli)
 
-Create and manage MongoDB Cloud resources from your command line and easily automate them using scripts
-
-The MongoDB CLI is the most seamless way to create and manage MongoDB Cloud resources. Spin up new database
-environments, create users, manage network access, and much more, all while avoiding repetitive tasks.
+The MongoDB CLI is a modern command line interface that enables you to manage your MongoDB services
+from the terminal.  Test, script, and execute other actions — all from one tool.
 
 ## Features
 

--- a/automatic/mongodb-cli/mongodb-cli.nuspec
+++ b/automatic/mongodb-cli/mongodb-cli.nuspec
@@ -6,29 +6,27 @@
     <version>2.0.3</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/mongodb-cli</packageSourceUrl>
     <owners>dgalbraith</owners>
-    <title>MongoDB Command Line Interface (mongocli)</title>
+    <title>MongoDB Command Line Interface</title>
     <authors>MongoDB</authors>
-    <projectUrl>https://www.mongodb.com/cloud/cli</projectUrl>
+    <projectUrl>https://github.com/mongodb/mongodb-cli</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@0be6f44308aeb981f08bca54c9e9a38ed158a326/icons/mongodb-cli.png</iconUrl>
     <copyright>Copyright MongoDB Inc</copyright>
-    <licenseUrl>https://github.com/mongodb/mongocli/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/mongodb/mongodb-cli/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/mongodb/mongocli</projectSourceUrl>
+    <projectSourceUrl>https://github.com/mongodb/mongodb-cli</projectSourceUrl>
     <docsUrl>https://www.mongodb.com/docs/mongocli/v2.0</docsUrl>
-    <bugTrackerUrl>https://github.com/mongodb/mongocli/issues</bugTrackerUrl>
-    <tags>mongodb mongocli cli mongodb-atlas mongodb-cloud-manager mongodb-ops-manager</tags>
-    <summary>Manage your MongoDB in the cloud</summary>
+    <bugTrackerUrl>https://github.com/mongodb/mongodb-cli/issues</bugTrackerUrl>
+    <tags>mongodb mongocli cli mongodb-cloud-manager mongodb-ops-manager</tags>
+    <summary>MongoDB CLI for Cloud Manager and Ops Manager</summary>
     <description><![CDATA[
 
-Create and manage MongoDB Cloud resources from your command line and easily automate them using scripts
-
-The MongoDB CLI is the most seamless way to create and manage MongoDB Cloud resources. Spin up new database
-environments, create users, manage network access, and much more, all while avoiding repetitive tasks.
+The MongoDB CLI is a modern command line interface that enables you to manage your MongoDB services
+from the terminal.  Test, script, and execute other actions — all from one tool.
 
 ## Features
 
-* **Unified control plane** Manage MongoDB Cloud services from MongoDB Atlas and Atlas Data Lake to management platforms
-such as MongoDB Ops Manager
+* **Simple commands** Use simple, one-line commands to interact with MongoDB Cloud Manager or Ops Manager, and
+to automate management tasks for your deployments
 
 * **Organize your resources** Create organizations and projects within your MongoDB Cloud account to easily isolate
 resources and manage access by team
@@ -46,7 +44,7 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://www.mongodb.com/docs/mongocli/v2.0/release-notes</releaseNotes>
+    <releaseNotes>https://www.mongodb.com/docs/mongocli/current/release-notes</releaseNotes>
     <dependencies>
       <dependency id="mongodb-cli.portable" version="[2.0.3]" />
     </dependencies>

--- a/automatic/mongodb-cli/update.ps1
+++ b/automatic/mongodb-cli/update.ps1
@@ -1,9 +1,12 @@
 ﻿import-module au
 
+Import-Module ..\..\scripts\chocolatey-helpers\Chocolatey-Helpers.psd1
+
 $ErrorActionPreference = 'STOP'
 
-$domain   = 'https://github.com'
-$releases = "${domain}/mongodb/mongodb-atlas-cli/releases/latest"
+$domain     = 'https://github.com'
+$user       = 'mongodb'
+$repository = 'mongodb-cli'
 
 $reChecksum     = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
 $reInstall      = "(?<=\d\/|\s|')(?<Filename>(m.+w.+msi))"
@@ -28,20 +31,17 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $downloadPage = Invoke-WebRequest -UseBasicParsing -Uri $releases
-  $latestTag    = $downloadPage.BaseResponse.ResponseUri -split '\/' | Select-Object -Last 1
-  $assetsUri    = "{0}/expanded_assets/mongocli/{1}" -f ($releases.Substring(0, $releases.LastIndexOf('/'))), $latestTag
-  $assetsPage   = Invoke-WebRequest -UseBasicParsing -Uri $assetsUri
+  $downloadPage = Get-GitHubLatestReleasePage -User $user -Repository $repository
 
-  $url64Install = $assetsPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
+  $url64Install = $downloadPage.links | where-object href -match $reInstall | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Install = $url64Install -split '/' | select-object -last 1
 
-  $url64Portable = $assetsPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
+  $url64Portable = $downloadPage.links | where-object href -match $rePortable | select-object -expand href | foreach-object { $domain + $_ }
   $fileName64Portable = $url64Portable -split '/' | select-object -last 1
 
   $version      = $url64Portable -match $reVersion | foreach-object { $Matches.Version }
   $shortVersion = $version -match '(?<ShortVersion>([\d]+\.[\d]+))'  | foreach-object { $Matches.ShortVersion }
-
+  
   return @{
     Url64Install       = $url64Install
     FileName64Install  = $fileName64Install


### PR DESCRIPTION
Software was split from the old repository shared with Atlas CLI to a dedicated stand-alone repository.
Adjusted package documentation, links and updates  to reflect the new repository.