### PR TITLE
(gh-613) Corrected spelling in documentation

### DIFF
--- a/automatic/dotcover-cli/dotcover-cli.nuspec
+++ b/automatic/dotcover-cli/dotcover-cli.nuspec
@@ -29,7 +29,7 @@ can be integrated with a Continuous Integration server.
 ## Notes
 
 * Related package: [dotcover](https://chocolatey.org/packages/dotCover)
-* The 64-bit version of the pacakge supports generatinv coverage for both 32 and 64-bit applications.
+* The 64-bit version of the pacakge supports generating coverage for both 32 and 64-bit applications.
 * The package installs a universal archive which contains the 32-bit and 64-bit versions of the tools.
 * This package is automatically updated using the [Chocolatey Automatic Package Update Model (AU)](https://github.com/majkinetor/au/blob/master/README.md).
   If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.


### PR DESCRIPTION
The documentation was using generatinv rather than generating.  Updated to correct spelling.