### PR TITLE
(gh-607) Updated packager distribution site

### DIFF
--- a/automatic/imagej/README.md
+++ b/automatic/imagej/README.md
@@ -1,9 +1,9 @@
 # [<img src="https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@a306a1daa4f210fa0a5421f2a3c996804629256a/icons/imagej.png" width="48" height="48" />ImageJ - Image Processing and Analysis in Java](https://chocolatey.org/packages/imagej)
 
-[![Software license](https://img.shields.io/badge/License-Public%20Domain-brightgreen.svg)](https://imagej.nih.gov/ij/disclaimer.html)
+[![Software license](https://img.shields.io/badge/License-Public%20Domain-brightgreen.svg)](https://imagej.net/ij/disclaimer.html)
 [![Maintenance status](https://img.shields.io/badge/maintained%3F-yes-green.svg)](https://gitHub.com/dgalbraith/chocolatey-packages/graphs/commit-activity)
 [![AppVeyor build](https://img.shields.io/appveyor/ci/dgalbraith/chocolatey-packages)](https://ci.appveyor.com/project/dgalbraith/chocolatey-packages)
-[![Software version](https://img.shields.io/badge/Source-v1.54-blue)](http://wsr.imagej.net/distros/win/ij152-win-java8.zip)
+[![Software version](https://img.shields.io/badge/Source-v1.54-blue)](https://imagej.net/ij/download.html)
 [![Chocolatey package version](https://img.shields.io/chocolatey/v/imagej?label=Chocolatey)](https://chocolatey.org/packages/imagej)
 
 Public domain software for processing and analyzing scientific images – a.k.a. ImageJ 1.x.

--- a/automatic/imagej/imagej.nuspec
+++ b/automatic/imagej/imagej.nuspec
@@ -8,14 +8,14 @@
     <owners>dgalbraith</owners>
     <title>ImageJ - Image Processing and Analysis in Java</title>
     <authors>Wayne Rasband</authors>
-    <projectUrl>https://imagej.nih.gov/ij</projectUrl>
+    <projectUrl>https://imagej.net/ij</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@a306a1daa4f210fa0a5421f2a3c996804629256a/icons/imagej.png</iconUrl>
     <copyright>ImageJ is dedicated to the public domain</copyright>
-    <licenseUrl>https://imagej.nih.gov/ij/disclaimer.html</licenseUrl>
+    <licenseUrl>https://imagej.net/ij/disclaimer.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/imagej/ImageJ</projectSourceUrl>
-    <docsUrl>https://imagej.nih.gov/ij/docs/index.html</docsUrl>
-    <mailingListUrl>https://imagej.nih.gov/ij/list.html</mailingListUrl>
+    <docsUrl>https://imagej.net/ij/docs/index.html</docsUrl>
+    <mailingListUrl>https://imagej.net/ij/list.html</mailingListUrl>
     <bugTrackerUrl>https://github.com/imagej/ImageJ/issues</bugTrackerUrl>
     <tags>imagej computer-vision image-analysis image-processing</tags>
     <summary>Image processing and analysis in Java</summary>
@@ -70,7 +70,7 @@ If you find it is out of date by more than a day or two, please contact the main
 
 ]]>
     </description>
-    <releaseNotes>https://imagej.nih.gov/ij/notes.html</releaseNotes>
+    <releaseNotes>https://imagej.net/ij/notes.html</releaseNotes>
     <dependencies />
   </metadata>
   <files>

--- a/automatic/imagej/legal/VERIFICATION.txt
+++ b/automatic/imagej/legal/VERIFICATION.txt
@@ -15,7 +15,7 @@ asset section of the distribution page.
 
 Alternatively the distribution can be downloaded directly from
 
-  http://wsr.imagej.net/distros/win/ij154-win-java8.zip
+  https://wsr.imagej.net/distros/win/ij154-win-java8.zip
 
 2. The archive can be validated by comparing checksums
   - Use powershell function 'Get-Filehash' - Get-Filehash ij154-win-java8.zip
@@ -25,4 +25,4 @@ Alternatively the distribution can be downloaded directly from
   ChecksumType: sha256
   Checksum:     32B05356D3A7906E10CA91491C2BE06BFE0397C9E7A3D3B52FDAD9E3EF48276C
 
-  Contents of file LICENSE.txt is obtained from https://imagej.nih.gov/ij/disclaimer.html
+  Contents of file LICENSE.txt is obtained from https://imagej.net/ij/disclaimer.html

--- a/automatic/imagej/update.ps1
+++ b/automatic/imagej/update.ps1
@@ -2,7 +2,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$releases = "https://imagej.nih.gov/ij/download.html"
+$releases = 'https://imagej.net/ij/download.html'
 
 $reArchive    = "(?<=\/|\s|')(?<Filename>(ij.+win.+zip))"
 $reChecksum   = '(?<=Checksum:\s*)((?<Checksum>([^\s].+)))'
@@ -51,4 +51,4 @@ function global:au_GetLatest {
   }
 }
 
-update -ChecksumFor none -NoReadme
+update -ChecksumFor none -NoCheckUrl -NoReadme


### PR DESCRIPTION
Updated the package distribution site from https://imagej.nih.gov/ij to https://imagej.net/ij.