### PR TITLE
(gh-632) Fixed shim creation  on install

### DIFF
--- a/automatic/nushell.install/README.md
+++ b/automatic/nushell.install/README.md
@@ -30,11 +30,10 @@ e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
 users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
-* `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user
+* `/User` - install the package for the current user only
+eg. `choco install nushell.install --package-parameters='"/User"'`.  Where the user parameter is specified any shortcuts
+created (using `/AddToDesktop` or `/AddToStartMenu`) will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
-
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 
 ## Notes
 

--- a/automatic/nushell.install/legal/LICENSE.txt
+++ b/automatic/nushell.install/legal/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2021 Yehuda Katz, Jonathan Turner
+Copyright (c) 2019 - 2025 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/automatic/nushell.install/nushell.install.nuspec
+++ b/automatic/nushell.install/nushell.install.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nushell.install</id>
-    <version>0.104.1</version>
+    <version>0.104.1.20250529</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nushell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Nushell - A new type of shell</title>
-    <authors>Jonathan Turner, Yehuda Katz, Andrés Robalino, Nushell Contributors</authors>
+    <authors>Jonathan Turner, Yehuda Katz, Andrés Robalino, Nushell Project Developers</authors>
     <projectUrl>https://www.nushell.sh</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@e1f9ccab58bbb3818c8b08f2ed977c0cbfae1d87/icons/nushell.png</iconUrl>
-    <copyright>Copyright 2019-2025 Yehuda Katz, Jonathan Turner</copyright>
+    <copyright>Copyright 2019-2025 The Nushell Project Developers</copyright>
     <licenseUrl>https://github.com/nushell/nushell/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/nushell/nushell</projectSourceUrl>
@@ -45,11 +45,10 @@ e.g. `choco install nushell.install --package-parameters="/AddToDesktop"`
 * `/AddToStartMenu` - add entries to the Start Menu for Koodoo Reader.  By default the shortcut will be added for all
 users
 e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
-* `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
-will only be added for the current user
+* `/User` - install the package for the current user only
+eg. `choco install nushell.install --package-parameters='"/User"'`.  Where the user parameter is specified any shortcuts
+created (using `/AddToDesktop` or `/AddToStartMenu`) will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
-
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 
 ## Notes
 

--- a/automatic/nushell.install/tools/chocolateyBeforeModify.ps1
+++ b/automatic/nushell.install/tools/chocolateyBeforeModify.ps1
@@ -19,3 +19,17 @@ $paths.GetEnumerator() | ForEach-Object {
     Remove-Item $_ -ErrorAction SilentlyContinue -Force | Out-Null
   }
 }
+
+$uninstallKey = Get-UninstallRegistryKey -SoftwareName 'Nushell'
+
+if ($uninstallKey) {
+  $installLocation = $uninstallKey.InstallLocation
+
+  if (($installLocation) -and ($installLocation -ne '') -and (Test-Path $installLocation)) {
+    Get-ChildItem -Path $installLocation -Recurse -Filter '*.exe' | foreach-object {
+      Uninstall-BinFile -Name ($_.Name -Replace '\.exe$','') -Path $_.FullName
+    }
+  }
+} else {
+  Write-Error "The uninstall key could not be found - shims have not been automatically removed."
+}

--- a/automatic/nushell.install/tools/chocolateyInstall.ps1
+++ b/automatic/nushell.install/tools/chocolateyInstall.ps1
@@ -2,75 +2,99 @@
 
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
+$silentArgs = '/qn /norestart'
+$pathScope  = 'Machine'
+
+$pp = Get-PackageParameters
+
+# install for all users (default), or the current user only if explicitly requested
+if ($pp.User) {
+  $silentArgs = 'ALLUSERS=2 MSIINSTALLPERUSER=1 ' + $silentArgs
+  $pathScope = 'User'
+} else {
+  # match the application folder to the hard-coded install location - regardless of
+  # what is specified the installer will always record [Environment]::GetFolderPath('ProgramFiles')\nu
+  # as the install location
+  $programFiles = [Environment]::GetFolderPath('ProgramFiles')
+  $silentArgs = "ALLUSERS=1 MSIINSTALLPERUSER=0 APPLICATIONFOLDER=`"$programFiles\nu`" $silentArgs"
+}
+
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
-  SoftwareName   = 'Nu'
+  SoftwareName   = 'Nushell'
   File64         = Join-Path $toolsDir 'nu-0.104.1-x86_64-pc-windows-msvc.msi'
   FileType       = 'msi'
-  SilentArgs     = '/qn /norestart'
+  SilentArgs     = $silentArgs
   ValidExitCodes = @(0, 3010, 1641)
 }
 
 # cache the path prior to package install so we can restore it - the installer
 # adds the bin directory from the install to the path but we will be using shims
 # so this is not needed
-$path = Get-EnvironmentVariable -name 'Path' -scope 'Machine' -PreserveVariables
+$path = Get-EnvironmentVariable -name 'Path' -scope $pathScope -PreserveVariables
 
 Install-ChocolateyInstallPackage @packageArgs
 
 # restore the cached path
-Install-ChocolateyEnvironmentVariable -VariableName 'Path' -VariableValue $path -VariableType Machine
+Install-ChocolateyEnvironmentVariable -VariableName 'Path' -VariableValue $path -VariableType $pathScope
 
-$uninstallKey    = Get-UninstallRegistryKey -SoftwareName 'Nu'
-$installLocation = $uninstallKey.InstallLocation
+$uninstallKey = Get-UninstallRegistryKey -SoftwareName 'Nushell' -ErrorAction SilentlyContinue
 
-Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
-  Install-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName
-}
+if ($uninstallKey) {
+  $installLocation = $uninstallKey.InstallLocation
 
-$pp = Get-PackageParameters
+  if (($installLocation) -and ($installLocation -ne '') -and (Test-Path $installLocation)) {
+    Get-ChildItem -Path $installLocation -Recurse -Filter '*.exe' | foreach-object {
+      Install-BinFile -Name ($_.Name -Replace '\.exe$','') -Path $_.FullName
+    }
 
-if ($pp.count -gt 0) {
-  $paths = New-Object System.Collections.ArrayList
+    if ($pp.count -gt 0) {
+      $paths = New-Object System.Collections.ArrayList
 
-  $pp.GetEnumerator() | foreach-object {
-    switch ($_.name) {
-        'AddToDesktop' {
-          Write-Verbose("Desktop shortcuts will be created for $env:ChocolateyPackageName")
-          if ($pp.User) {
-            $desktopPath = [Environment]::GetFolderPath('Desktop')
-          } else {
-            $desktopPath = [Environment]::GetFolderPath('CommonDesktopDirectory')
+      $pp.GetEnumerator() | foreach-object {
+        switch ($_.name) {
+          'AddToDesktop' {
+            Write-Verbose("Desktop shortcuts will be created for $env:ChocolateyPackageName")
+            if ($pp.User) {
+              $desktopPath = [Environment]::GetFolderPath('Desktop')
+            }
+            else {
+              $desktopPath = [Environment]::GetFolderPath('CommonDesktopDirectory')
+            }
+
+            $paths.Add($desktopPath) | Out-Null
           }
+          'AddToStartMenu' {
+            Write-Verbose("$env:ChocolateyPackageName will be added to the Start Menu")
+            if ($pp.User) {
+              $startMenuPath = [Environment]::GetFolderPath('StartMenu')
+            }
+            else {
+              $startMenuPath = [Environment]::GetFolderPath('CommonStartMenu')
+            }
 
-          $paths.add($desktopPath) | Out-Null
-        }
-        'AddToStartMenu' {
-          Write-Verbose("$env:ChocolateyPackageName will be added to the Start Menu")
-          if ($pp.User) {
-            $startMenuPath = [Environment]::GetFolderPath('StartMenu')
-          } else {
-            $startMenuPath = [Environment]::GetFolderPath('CommonStartMenu')
+            $paths.Add($startMenuPath) | Out-Null
           }
+          'User' {
+            # ignore - no need to handle independently as it is a qualifier for other options
+          }
+          Default {
+            Write-Verbose("Unknown parameter $_.name will be ignored")
+          }
+        }
+      }
 
-          $paths.Add($startMenuPath) | Out-Null
+      if ($paths.Count -gt 0) {
+        $executable = Join-Path $installLocation 'bin' | Join-Path -ChildPath 'nu.exe'
+        $icon = Join-Path $toolsDir 'nushell.ico'
+
+        $paths.GetEnumerator() | foreach-object {
+          $shortcutPath = Join-Path $_ 'Nu Shell.lnk'
+          Install-ChocolateyShortcut -ShortcutFilePath $shortcutPath -TargetPath $executable -WorkingDirectory '%USERPROFILE%' -IconLocation $icon
         }
-        'User' {
-          # ignore - no need to handle independently as it is a qualifier for other options
-        }
-        Default {
-          Write-Verbose("Unknown parameter $_.name will be ignored")
-        }
+      }
     }
   }
-
-  if ($paths.Count -gt 0) {
-    $executable = Join-Path $installLocation 'bin' | Join-Path -ChildPath 'nu.exe'
-    $icon       = Join-Path $toolsDir 'nushell.ico'
-
-    $paths.GetEnumerator() | foreach-object {
-      $shortcutPath = Join-Path $_ 'Nu Shell.lnk'
-      Install-ChocolateyShortcut -ShortcutFilePath $shortcutPath -TargetPath $executable -WorkingDirectory '%userprofile%' -IconLocation $icon
-    }
-  }
+} else {
+  throw 'Unable to find the Nushell uninstall key. The package may not have been installed correctly.'
 }

--- a/automatic/nushell.install/tools/chocolateyUninstall.ps1
+++ b/automatic/nushell.install/tools/chocolateyUninstall.ps1
@@ -1,8 +1,0 @@
-﻿$ErrorActionPreference = 'Stop'
-
-$uninstallKey    = Get-UninstallRegistryKey -SoftwareName 'Nu'
-$installLocation = $uninstallKey.InstallLocation
-
-Get-ChildItem $installLocation -recurse -include '*.exe' | foreach-object {
-  Uninstall-BinFile -Name ($_.Name -Replace '\..*') -Path $_.FullName
-}

--- a/automatic/nushell.portable/README.md
+++ b/automatic/nushell.portable/README.md
@@ -34,8 +34,6 @@ e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
 
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
-
 ## Notes
 
 * Nushell only provides a 64-bit version

--- a/automatic/nushell.portable/legal/LICENSE.txt
+++ b/automatic/nushell.portable/legal/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2021 Yehuda Katz, Jonathan Turner
+Copyright (c) 2019 - 2025 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/automatic/nushell.portable/nushell.portable.nuspec
+++ b/automatic/nushell.portable/nushell.portable.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nushell.portable</id>
-    <version>0.104.1</version>
+    <version>0.104.1.20250529</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nushell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Nushell - A new type of shell (Portable)</title>
-    <authors>Jonathan Turner, Yehuda Katz, Andrés Robalino, Nushell Contributors</authors>
+    <authors>Jonathan Turner, Yehuda Katz, Andrés Robalino, Nushell Project Developers</authors>
     <projectUrl>https://www.nushell.sh</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@e1f9ccab58bbb3818c8b08f2ed977c0cbfae1d87/icons/nushell.png</iconUrl>
-    <copyright>Copyright 2019-2025 Yehuda Katz, Jonathan Turner</copyright>
+    <copyright>Copyright 2019-2025 The Nushell Project Developers</copyright>
     <licenseUrl>https://github.com/nushell/nushell/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/nushell/nushell</projectSourceUrl>
@@ -48,8 +48,6 @@ e.g. `choco install nushell.install --package-parameters="/AddToStartMenu"`
 * `/User` - where the user parameter is specified any shortcuts created (using `/AddToDesktop` or `/AddToStartMenu`)
 will only be added for the current user
 e.g. `choco install nushell.install --package-parameters="/AddToDesktop /User"`
-
-To have Chocolatey remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 
 ## Notes
 

--- a/automatic/nushell.portable/tools/chocolateyInstall.ps1
+++ b/automatic/nushell.portable/tools/chocolateyInstall.ps1
@@ -25,7 +25,7 @@ if ($pp.count -gt 0) {
             $desktopPath = [Environment]::GetFolderPath('CommonDesktopDirectory')
           }
 
-          $paths.add($desktopPath) | Out-Null
+          $paths.Add($desktopPath) | Out-Null
         }
         'AddToStartMenu' {
           Write-Verbose("$env:ChocolateyPackageName will be added to the Start Menu")
@@ -47,12 +47,12 @@ if ($pp.count -gt 0) {
   }
 
   if ($paths.Count -gt 0) {
-    $executable = Get-ChildItem $toolsDir -recurse -include 'nu.exe' | foreach-object { $_.FullName }
+    $executable = Get-ChildItem $toolsDir -Recurse -Filter 'nu.exe' | Select-Object -First 1 | ForEach-Object { $_.FullName }
     $icon       = Join-Path $toolsDir 'nushell.ico'
 
     $paths.GetEnumerator() | foreach-object {
       $shortcutPath = Join-Path $_ 'Nu Shell.lnk'
-      Install-ChocolateyShortcut -ShortcutFilePath $shortcutPath -TargetPath $executable -WorkingDirectory '%userprofile%' -IconLocation $icon
+      Install-ChocolateyShortcut -ShortcutFilePath $shortcutPath -TargetPath $executable -WorkingDirectory '%USERPROFILE%' -IconLocation $icon
     }
   }
 }

--- a/automatic/nushell/nushell.nuspec
+++ b/automatic/nushell/nushell.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nushell</id>
-    <version>0.104.1</version>
+    <version>0.104.1.20250529</version>
     <packageSourceUrl>https://github.com/dgalbraith/chocolatey-packages/tree/master/automatic/nushell</packageSourceUrl>
     <owners>dgalbraith</owners>
     <title>Nushell - A new type of shell</title>
-    <authors>Jonathan Turner, Yehuda Katz, Andrés Robalino, Nushell Contributors</authors>
+    <authors>Jonathan Turner, Yehuda Katz, Andrés Robalino, Nushell Proejct Developers</authors>
     <projectUrl>https://www.nushell.sh</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/dgalbraith/chocolatey-packages@e1f9ccab58bbb3818c8b08f2ed977c0cbfae1d87/icons/nushell.png</iconUrl>
-    <copyright>Copyright 2019-2025 Yehuda Katz, Jonathan Turner</copyright>
+    <copyright>Copyright 2019-2025 The Nushell Project Developers</copyright>
     <licenseUrl>https://github.com/nushell/nushell/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/nushell/nushell</projectSourceUrl>
@@ -60,7 +60,7 @@ If you find it is out of date by more than a day or two, please contact the main
 ]]></description>
     <releaseNotes>https://github.com/nushell/nushell/releases/tag/0.104.1</releaseNotes>
     <dependencies>
-      <dependency id="nushell.install" version="[0.104.1]" />
+      <dependency id="nushell.install" version="[0.104.1.20250529]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Shim creation was not functioning as intended.  The registry key was not being matched which was resulting in shim creation picking up .exe files recursively  beneath the directory from which the chocolatey command was launched.

This was due to an update to the installer - the name was changed from nu to nushell which disruped the existing logic - the registry key used to determine install location was no longer being located.

* Modified handling to address this as well as increased the robustness of the install location handling.
* Updated the license files, author and copyright information to reflect current source
* Updated isntall handling to install for all users unless specifically targeted as a per user install
* Ensured that the correct parameters (including install dir) were passed to the installer
* Moved the shim removal from chocolateyUninstall to chocolateyBeforeModify