### PR TITLE
(gh-635) Add Chocolatey shim for Midnight Commander (mc)

### DIFF
--- a/automatic/mc/tools/chocolateyInstall.ps1
+++ b/automatic/mc/tools/chocolateyInstall.ps1
@@ -40,3 +40,7 @@ $packageArgs = @{
 }
 
 Install-ChocolateyInstallPackage @packageArgs
+
+# Create Shim
+$exePath = Join-Path "$env:ProgramFiles\Midnight Commander" 'mc.exe'
+Install-BinFile -Name 'mc' -Path $exePath

--- a/automatic/mc/tools/chocolateyUninstall.ps1
+++ b/automatic/mc/tools/chocolateyUninstall.ps1
@@ -16,3 +16,5 @@ Get-ItemProperty -Path @( 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentV
                                                  -SilentArgs "$($silentArgs)" `
                                                  -File "$($_.UninstallString.Replace('"',''))" `
                                                  -ValidExitCodes $validExitCodes }
+
+Uninstall-BinFile -Name 'mc'


### PR DESCRIPTION
This PR adds a Chocolatey shim for the `mc` executable using `Install-BinFile` in `chocolateyInstall.ps1`.

It also adds a `chocolateyUninstall.ps1` with a corresponding `Uninstall-BinFile` call to properly clean up the shim on package removal.

