### PR TITLE
Fix parsing of Android Studio version from url

### DIFF
--- a/automatic/androidstudio/update.ps1
+++ b/automatic/androidstudio/update.ps1
@@ -35,7 +35,7 @@ function global:au_GetLatest {
     $filename = $url -split '/' | Select-Object -Last 1
 
     $updateYear = (Get-Date).ToString('yyyy')
-    $version   = $url -split '-' | Select-Object -Last 1 -Skip 1
+    $version   = $url -split '/' | Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } | Select-Object -Last 1
 
     return @{
       Url64      = $url


### PR DESCRIPTION
Previous download urls for Android studio looked like `../android/studio/install/2025.2.3.7/android-studio-2025.2.3.7-windows.exe`. The url format has been changed in recent updates to look like `../android/studio/install/2025.3.4.7/android-studio-panda4-patch1-windows.exe` resulting in the error `Invalid version: patch1`.

This commit changes the version search to parse the url segment before the file name for the version.